### PR TITLE
Here's my revised plan for correcting the JSP paths:

### DIFF
--- a/src/main/java/com/eventmaster/controller/EventoServlet.java
+++ b/src/main/java/com/eventmaster/controller/EventoServlet.java
@@ -337,7 +337,7 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
             request.setAttribute("fechaHoraInput", evento.getFechaHora().format(inputFormatter));
         }
 
-        request.getRequestDispatcher("/WEB-INF/jsp/evento/editarEventoForm.jsp").forward(request, response);
+        request.getRequestDispatcher("/jsp/evento/editarEventoForm.jsp").forward(request, response);
     }
 
     private void procesarEditarEvento(HttpServletRequest request, HttpServletResponse response)
@@ -392,7 +392,7 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                     DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
                     request.setAttribute("fechaHoraInput", eventoAEditar.getFechaHora().format(inputFormatter));
                 }
-                request.getRequestDispatcher("/WEB-INF/jsp/evento/editarEventoForm.jsp").forward(request, response);
+                request.getRequestDispatcher("/jsp/evento/editarEventoForm.jsp").forward(request, response);
                 return;
             }
             LocalDateTime fechaHora = LocalDateTime.parse(fechaHoraStr);
@@ -419,7 +419,7 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                 DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
                 request.setAttribute("fechaHoraInput", eventoAEditar.getFechaHora().format(inputFormatter));
             }
-            request.getRequestDispatcher("/WEB-INF/jsp/evento/editarEventoForm.jsp").forward(request, response);
+            request.getRequestDispatcher("/jsp/evento/editarEventoForm.jsp").forward(request, response);
         } catch (NumberFormatException e) {
             request.setAttribute("errorEditarEvento", "Capacidad debe ser un número.");
             request.setAttribute("evento", eventoAEditar); // Reenviar datos originales
@@ -427,7 +427,7 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                 DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
                 request.setAttribute("fechaHoraInput", eventoAEditar.getFechaHora().format(inputFormatter));
             }
-            request.getRequestDispatcher("/WEB-INF/jsp/evento/editarEventoForm.jsp").forward(request, response);
+            request.getRequestDispatcher("/jsp/evento/editarEventoForm.jsp").forward(request, response);
         } catch (IllegalArgumentException | IllegalStateException e) {
             request.setAttribute("errorEditarEvento", "Error al actualizar evento: " + e.getMessage());
             request.setAttribute("evento", eventoAEditar); // Reenviar datos originales
@@ -435,7 +435,7 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                 DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
                 request.setAttribute("fechaHoraInput", eventoAEditar.getFechaHora().format(inputFormatter));
             }
-            request.getRequestDispatcher("/WEB-INF/jsp/evento/editarEventoForm.jsp").forward(request, response);
+            request.getRequestDispatcher("/jsp/evento/editarEventoForm.jsp").forward(request, response);
         }
     }
 

--- a/src/main/java/com/eventmaster/controller/HomeServlet.java
+++ b/src/main/java/com/eventmaster/controller/HomeServlet.java
@@ -50,8 +50,8 @@ public class HomeServlet extends HttpServlet {
             // e.printStackTrace(); // Para depuración
         }
 
-        RequestDispatcher dispatcher = request.getRequestDispatcher("/index.jsp"); // Asumiendo que tienes un index.jsp en la raíz de webapp
-        // O si está en WEB-INF/jsp: request.getRequestDispatcher("/WEB-INF/jsp/home.jsp");
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/jsp/index.jsp");
+        // O si está en WEB-INF/jsp: request.getRequestDispatcher("/WEB-INF/jsp/home.jsp"); // Comentario original mantenido por contexto
         dispatcher.forward(request, response);
     }
 }

--- a/src/main/webapp/WEB-INF/jsp/evento/editarEventoForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/evento/editarEventoForm.jsp
@@ -8,8 +8,8 @@
     <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/css/style.css">
 </head>
 <body>
-    <jsp:include page="/WEB-INF/jsp/common/header.jsp" />
-    <jsp:include page="/WEB-INF/jsp/common/navigation.jsp" />
+    <jsp:include page="/jsp/common/header.jsp" />
+    <jsp:include page="/jsp/common/navigation.jsp" />
 
     <div class="container">
         <h2>Editar Evento: <c:out value="${evento.nombre}" /></h2>
@@ -72,6 +72,6 @@
         </c:choose>
     </div>
 
-    <jsp:include page="/WEB-INF/jsp/common/footer.jsp" />
+    <jsp:include page="/jsp/common/footer.jsp" />
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -67,7 +67,7 @@
     <!-- Página de Bienvenida (lo que se sirve en la raíz si HomeServlet no estuviera mapeado a "/") -->
     <!-- En nuestro caso, HomeServlet ya maneja la raíz, pero es bueno tenerlo -->
     <welcome-file-list>
-        <welcome-file>index.jsp</welcome-file> <%-- O index.html, o la URL que maneje HomeServlet --%>
+        <welcome-file>jsp/index.jsp</welcome-file> <%-- O index.html, o la URL que maneje HomeServlet --%>
     </welcome-file-list>
 
     <!-- Configuración de Páginas de Error (opcional, pero recomendado) -->


### PR DESCRIPTION
I'll update the paths in RequestDispatchers (Servlets) and `<jsp:include>` tags (JSPs) to reflect the new location of the 'jsp' folder directly under 'webapp' instead of 'webapp/WEB-INF/jsp'.

Here are the main changes I'll make:
- Modify the includes in `editarEventoForm.jsp`.
- Update the RequestDispatcher paths in `EventoServlet` for `editarEventoForm.jsp`.
- Update the RequestDispatcher path in `HomeServlet` for `index.jsp`.
- Update the `<welcome-file>` entry in `web.xml` for `index.jsp`.

Most of the other JSPs and Servlets already seem to be using the correct paths.