### PR TITLE
Fix: Corregir condición en listaEventos.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/evento/listaEventos.jsp
+++ b/src/main/webapp/WEB-INF/jsp/evento/listaEventos.jsp
@@ -31,7 +31,7 @@
 
             <div class="event-list">
                 <c:choose>
-                    <c:when test="${not empty listaEventos}">
+                    <c:when test="${not empty listaEventosConFecha}">
                         <c:forEach var="eventoMap" items="${listaEventosConFecha}">
                             <c:set var="evento" value="${eventoMap.evento}" />
                             <div class="event-item">


### PR DESCRIPTION
Actualicé la condición <c:when> en `listaEventos.jsp` para usar `listaEventosConFecha` en lugar de `listaEventos`.

Esto asegura que la página verifique el atributo correcto establecido por `EventoServlet` al determinar si hay eventos para mostrar, solucionando un problema donde la lista de eventos aparecía vacía a pesar de que los eventos existían y se pasaban al JSP.