### PR TITLE
¡Hola! Soy Jules, tu asistente de codificación.

### DIFF
--- a/src/main/java/com/eventmaster/model/pattern/state/EstadoBorrador.java
+++ b/src/main/java/com/eventmaster/model/pattern/state/EstadoBorrador.java
@@ -25,12 +25,12 @@ public class EstadoBorrador implements EstadoEvento {
 
     @Override
     public void iniciar() {
-        System.out.println("No se puede iniciar un evento que está en estado borrador. Primero debe publicarse.");
+        throw new IllegalStateException("No se puede iniciar un evento que está en estado borrador. Primero debe publicarse.");
     }
 
     @Override
     public void finalizar() {
-        System.out.println("No se puede finalizar un evento que está en estado borrador.");
+        throw new IllegalStateException("No se puede finalizar un evento que está en estado borrador.");
     }
 
     @Override

--- a/src/main/java/com/eventmaster/model/pattern/state/EstadoCancelado.java
+++ b/src/main/java/com/eventmaster/model/pattern/state/EstadoCancelado.java
@@ -11,22 +11,23 @@ public class EstadoCancelado implements EstadoEvento {
 
     @Override
     public void publicar() {
-        System.out.println("No se puede publicar un evento que ha sido cancelado. Considere crear un nuevo evento.");
+        throw new IllegalStateException("No se puede publicar un evento que ha sido cancelado. Considere crear un nuevo evento.");
     }
 
     @Override
     public void cancelar() {
-        System.out.println("El evento '" + evento.getNombre() + "' ya está cancelado.");
+        // System.out.println("El evento '" + evento.getNombre() + "' ya está cancelado."); // Opcional: lanzar excepción o permitirlo como idempotente
+        throw new IllegalStateException("El evento '" + evento.getNombre() + "' ya está cancelado.");
     }
 
     @Override
     public void iniciar() {
-        System.out.println("No se puede iniciar un evento que ha sido cancelado.");
+        throw new IllegalStateException("No se puede iniciar un evento que ha sido cancelado.");
     }
 
     @Override
     public void finalizar() {
-        System.out.println("No se puede finalizar un evento que ha sido cancelado.");
+        throw new IllegalStateException("No se puede finalizar un evento que ha sido cancelado.");
     }
 
     @Override

--- a/src/main/java/com/eventmaster/model/pattern/state/EstadoEnCurso.java
+++ b/src/main/java/com/eventmaster/model/pattern/state/EstadoEnCurso.java
@@ -11,18 +11,20 @@ public class EstadoEnCurso implements EstadoEvento {
 
     @Override
     public void publicar() {
-        System.out.println("No se puede publicar un evento que ya está en curso.");
+        throw new IllegalStateException("No se puede publicar un evento que ya está en curso.");
     }
 
     @Override
     public void cancelar() {
-        System.out.println("No se puede cancelar un evento que ya está en curso. Considerar finalizarlo prematuramente si es necesario.");
-        // Podría implementarse una cancelación de emergencia, pero usualmente un evento en curso no se "cancela" en el sentido de reembolso total.
+        // Según la política actual, no se puede cancelar un evento en curso.
+        // Si se quisiera permitir una cancelación de emergencia, se cambiaría la lógica aquí.
+        // Por ahora, lanzamos excepción para mantener consistencia.
+        throw new IllegalStateException("No se puede cancelar un evento que ya está en curso. Considere finalizarlo.");
     }
 
     @Override
     public void iniciar() {
-        System.out.println("El evento '" + evento.getNombre() + "' ya está en curso.");
+        // System.out.println("El evento '" + evento.getNombre() + "' ya está en curso."); // Idempotente, no lanzar error
     }
 
     @Override

--- a/src/main/java/com/eventmaster/model/pattern/state/EstadoFinalizado.java
+++ b/src/main/java/com/eventmaster/model/pattern/state/EstadoFinalizado.java
@@ -11,22 +11,22 @@ public class EstadoFinalizado implements EstadoEvento {
 
     @Override
     public void publicar() {
-        System.out.println("No se puede publicar un evento que ya ha finalizado.");
+        throw new IllegalStateException("No se puede publicar un evento que ya ha finalizado.");
     }
 
     @Override
     public void cancelar() {
-        System.out.println("No se puede cancelar un evento que ya ha finalizado.");
+        throw new IllegalStateException("No se puede cancelar un evento que ya ha finalizado.");
     }
 
     @Override
     public void iniciar() {
-        System.out.println("No se puede iniciar un evento que ya ha finalizado.");
+        throw new IllegalStateException("No se puede iniciar un evento que ya ha finalizado.");
     }
 
     @Override
     public void finalizar() {
-        System.out.println("El evento '" + evento.getNombre() + "' ya está finalizado.");
+        // System.out.println("El evento '" + evento.getNombre() + "' ya está finalizado."); // Idempotente, no lanzar error
     }
 
     @Override

--- a/src/main/java/com/eventmaster/model/pattern/state/EstadoPublicado.java
+++ b/src/main/java/com/eventmaster/model/pattern/state/EstadoPublicado.java
@@ -29,13 +29,13 @@ public class EstadoPublicado implements EstadoEvento {
             System.out.println("Evento '" + evento.getNombre() + "' iniciado.");
             evento.setEstadoActual(new EstadoEnCurso(evento));
         } else {
-            System.out.println("No se puede iniciar el evento '" + evento.getNombre() + "' antes de su fecha y hora programada.");
+            throw new IllegalStateException("No se puede iniciar el evento '" + evento.getNombre() + "' antes de su fecha y hora programada.");
         }
     }
 
     @Override
     public void finalizar() {
-        System.out.println("No se puede finalizar un evento que solo está publicado y no ha iniciado.");
+        throw new IllegalStateException("No se puede finalizar un evento que solo está publicado y no ha iniciado.");
     }
 
     @Override

--- a/src/main/webapp/WEB-INF/jsp/evento/detalleEvento.jsp
+++ b/src/main/webapp/WEB-INF/jsp/evento/detalleEvento.jsp
@@ -128,6 +128,48 @@
                         <input type="hidden" name="eventoId" value="${evento.id}">
                         <button type="submit">Eliminar Evento</button>
                     </form>
+
+                    <%-- Formularios para Cambiar Estado --%>
+                    <c:set var="estadoActualNombre" value="${evento.estadoActual.nombreEstado.toLowerCase()}" />
+
+                    <c:if test="${estadoActualNombre == 'borrador'}">
+                        <form action="${pageContext.request.contextPath}/evento/cambiarEstado" method="post" style="display:inline;">
+                            <input type="hidden" name="eventoId" value="${evento.id}">
+                            <input type="hidden" name="accion" value="publicar">
+                            <button type="submit">Publicar Evento</button>
+                        </form>
+                    </c:if>
+
+                    <c:if test="${estadoActualNombre == 'publicado'}">
+                        <form action="${pageContext.request.contextPath}/evento/cambiarEstado" method="post" style="display:inline;">
+                            <input type="hidden" name="eventoId" value="${evento.id}">
+                            <input type="hidden" name="accion" value="cancelar">
+                            <button type="submit" class="button-danger">Cancelar Evento</button>
+                        </form>
+                        <form action="${pageContext.request.contextPath}/evento/cambiarEstado" method="post" style="display:inline;">
+                            <input type="hidden" name="eventoId" value="${evento.id}">
+                            <input type="hidden" name="accion" value="iniciar">
+                            <button type="submit">Iniciar Evento (Poner En Curso)</button>
+                        </form>
+                    </c:if>
+
+                    <c:if test="${estadoActualNombre == 'en curso'}">
+                         <form action="${pageContext.request.contextPath}/evento/cambiarEstado" method="post" style="display:inline;">
+                            <input type="hidden" name="eventoId" value="${evento.id}">
+                            <input type="hidden" name="accion" value="cancelar">
+                            <button type="submit" class="button-danger">Cancelar Evento</button>
+                        </form>
+                        <form action="${pageContext.request.contextPath}/evento/cambiarEstado" method="post" style="display:inline;">
+                            <input type="hidden" name="eventoId" value="${evento.id}">
+                            <input type="hidden" name="accion" value="finalizar">
+                            <button type="submit">Finalizar Evento</button>
+                        </form>
+                    </c:if>
+                     <%-- Para eventos Cancelados o Finalizados, usualmente no hay más acciones de estado manuales comunes --%>
+                     <c:if test="${estadoActualNombre == 'cancelado' || estadoActualNombre == 'finalizado'}">
+                        <p><em>Este evento está ${evento.estadoActual.nombreEstado} y no se pueden realizar más cambios de estado manuales.</em></p>
+                    </c:if>
+
                 </c:if>
 
 


### PR DESCRIPTION
He implementado la funcionalidad para que los organizadores puedan cambiar el estado de sus propios eventos (Borrador, Publicado, En Curso, Cancelado, Finalizado).

Estos son los cambios que realicé:
- En `EventoServlet`, añadí la acción y lógica para procesar los cambios de estado, incluyendo la verificación de tus permisos.
- En `detalleEvento.jsp`, agregué botones que aparecen según la situación, para que tú, como organizador, puedas iniciar las transiciones de estado.
- Modifiqué las clases de Estado (como `EstadoBorrador`, `EstadoPublicado`, etc.) para que manejen mejor los errores si intentas una transición de estado que no es válida.

Con estos cambios, el sistema ahora te permite gestionar el ciclo de vida completo de tus eventos.