### PR TITLE
Feat: Permitir definición de tipo de entrada básico al crear evento

### DIFF
--- a/src/main/java/com/eventmaster/controller/EventoServlet.java
+++ b/src/main/java/com/eventmaster/controller/EventoServlet.java
@@ -278,8 +278,28 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                 .setCategoria(categoria)
                 .setCapacidadTotal(capacidad > 0 ? capacidad : lugarSimulado.obtenerCapacidadTotal());
 
-            // Aquí se podrían añadir Tipos de Entrada desde el formulario
-            // Ejemplo: builder.addTipoEntrada("General", new com.eventmaster.model.pattern.factory.TipoEntrada("General", 25.00, 100, 5));
+            // Leer datos del tipo de entrada principal del formulario
+            String tipoEntradaNombre = request.getParameter("tipoEntradaNombre");
+            double tipoEntradaPrecioBase = Double.parseDouble(request.getParameter("tipoEntradaPrecioBase"));
+            int tipoEntradaCantidadTotal = Integer.parseInt(request.getParameter("tipoEntradaCantidadTotal"));
+            int tipoEntradaLimiteCompra = Integer.parseInt(request.getParameter("tipoEntradaLimiteCompra"));
+
+            if (tipoEntradaNombre != null && !tipoEntradaNombre.trim().isEmpty() && tipoEntradaPrecioBase >= 0 && tipoEntradaCantidadTotal > 0 && tipoEntradaLimiteCompra > 0) {
+                com.eventmaster.model.pattern.factory.TipoEntrada tipoEntradaPrincipal =
+                        new com.eventmaster.model.pattern.factory.TipoEntrada(
+                                tipoEntradaNombre,
+                                tipoEntradaPrecioBase,
+                                tipoEntradaCantidadTotal,
+                                tipoEntradaLimiteCompra
+                        );
+                builder.addTipoEntrada(tipoEntradaNombre, tipoEntradaPrincipal);
+                System.out.println("EventoServlet: Añadido tipo de entrada '" + tipoEntradaNombre + "' al evento '" + nombre + "'.");
+            } else {
+                // Opcional: ¿Qué hacer si los datos del tipo de entrada son inválidos o no se proporcionan?
+                // Podríamos lanzar un error, o crear el evento sin tipos de entrada, o con uno por defecto.
+                // Por ahora, si no son válidos, el evento se creará sin este tipo de entrada.
+                 System.out.println("EventoServlet: Datos para el tipo de entrada principal no proporcionados o inválidos para el evento '" + nombre + "'.");
+            }
 
             Evento eventoParaGuardar = builder.build(); // Construir el evento primero
             Evento eventoGuardado = eventoService.registrarNuevoEvento(eventoParaGuardar); // Luego pasarlo al servicio

--- a/src/main/webapp/WEB-INF/jsp/evento/crearEventoForm.jsp
+++ b/src/main/webapp/WEB-INF/jsp/evento/crearEventoForm.jsp
@@ -48,7 +48,26 @@
                         <input type="number" id="capacidad" name="capacidad" value="${param.capacidad != null ? param.capacidad : 100}" min="1" required>
                     </div>
 
-                    <p><em>Los tipos de entrada se podrán configurar después de crear el evento base.</em></p>
+                    <hr/>
+                    <h4>Definir un Tipo de Entrada Principal</h4>
+                    <div>
+                        <label for="tipoEntradaNombre">Nombre del Tipo de Entrada:</label>
+                        <input type="text" id="tipoEntradaNombre" name="tipoEntradaNombre" value="${not empty param.tipoEntradaNombre ? param.tipoEntradaNombre : 'General'}" required>
+                        (Ej: General, VIP, Preventa)
+                    </div>
+                    <div>
+                        <label for="tipoEntradaPrecioBase">Precio Base (€):</label>
+                        <input type="number" id="tipoEntradaPrecioBase" name="tipoEntradaPrecioBase" value="${not empty param.tipoEntradaPrecioBase ? param.tipoEntradaPrecioBase : '25.00'}" step="0.01" min="0" required>
+                    </div>
+                    <div>
+                        <label for="tipoEntradaCantidadTotal">Cantidad Disponible para este Tipo:</label>
+                        <input type="number" id="tipoEntradaCantidadTotal" name="tipoEntradaCantidadTotal" value="${not empty param.tipoEntradaCantidadTotal ? param.tipoEntradaCantidadTotal : '100'}" min="1" required>
+                    </div>
+                     <div>
+                        <label for="tipoEntradaLimiteCompra">Límite de Compra por Usuario (para este tipo):</label>
+                        <input type="number" id="tipoEntradaLimiteCompra" name="tipoEntradaLimiteCompra" value="${not empty param.tipoEntradaLimiteCompra ? param.tipoEntradaLimiteCompra : '10'}" min="1" required>
+                    </div>
+                    <hr/>
 
                     <div>
                         <button type="submit">Crear Evento</button>


### PR DESCRIPTION
Implementa la Fase 1 para la gestión de tipos de entrada:
- Modificado crearEventoForm.jsp para incluir campos para definir un nombre de tipo de entrada, precio, cantidad y límite de compra.
- Actualizado EventoServlet#procesarCrearEvento para leer estos datos, crear un objeto TipoEntrada y asociarlo al evento.
- Verificados EventoService y TipoEntradaDAO para asegurar que el guardado y carga de estos tipos de entrada funcionen.

Este cambio permite que la tabla 'Tipos de Entrada Disponibles' en la página de detalle del evento se pueble con al menos un tipo de entrada definido por el organizador.