### PR TITLE
Fix: Corregir manejo de decoradores en Facade y Command

### DIFF
--- a/src/main/java/com/eventmaster/model/command/ComprarEntradaCommand.java
+++ b/src/main/java/com/eventmaster/model/command/ComprarEntradaCommand.java
@@ -15,6 +15,8 @@ public class ComprarEntradaCommand implements Command {
     private int cantidad;
     private Map<String, Object> detallesPago;
     private String codigoDescuento; // Opcional
+    private boolean aplicarMercancia;
+    private boolean aplicarDescuento;
 
     private ProcesoCompraFacade procesoCompraFacade;
     private Compra compraRealizada; // Para el undo y para obtener el resultado
@@ -22,6 +24,7 @@ public class ComprarEntradaCommand implements Command {
 
     public ComprarEntradaCommand(Usuario usuario, String eventoId, String tipoEntradaNombre, int cantidad,
                                  Map<String, Object> detallesPago, String codigoDescuento,
+                                 boolean aplicarMercancia, boolean aplicarDescuento,
                                  ProcesoCompraFacade procesoCompraFacade) {
         this.usuario = usuario;
         this.eventoId = eventoId;
@@ -29,22 +32,28 @@ public class ComprarEntradaCommand implements Command {
         this.cantidad = cantidad;
         this.detallesPago = detallesPago;
         this.codigoDescuento = codigoDescuento;
+        this.aplicarMercancia = aplicarMercancia;
+        this.aplicarDescuento = aplicarDescuento;
         this.procesoCompraFacade = procesoCompraFacade;
     }
 
+    // Constructor anterior simplificado, ahora debe incluir los booleanos o tener valores por defecto
     public ComprarEntradaCommand(Usuario usuario, String eventoId, String tipoEntradaNombre, int cantidad,
                                  Map<String, Object> detallesPago, ProcesoCompraFacade procesoCompraFacade) {
-        this(usuario, eventoId, tipoEntradaNombre, cantidad, detallesPago, null, procesoCompraFacade);
+        this(usuario, eventoId, tipoEntradaNombre, cantidad, detallesPago, null, false, false, procesoCompraFacade); // Por defecto, no aplicar decoradores
     }
 
 
     @Override
     public boolean execute() {
         this.tiempoEjecucion = LocalDateTime.now();
-        System.out.println("Comando ComprarEntrada: Ejecutando para usuario " + usuario.getNombre() + ", Evento ID: " + eventoId + ", Tipo: " + tipoEntradaNombre + ", Cant: " + cantidad);
+        System.out.println("Comando ComprarEntrada: Ejecutando para usuario " + usuario.getNombre() +
+                           ", Evento ID: " + eventoId + ", Tipo: " + tipoEntradaNombre + ", Cant: " + cantidad +
+                           ", Mercancía: " + aplicarMercancia + ", Descuento: " + aplicarDescuento);
         try {
             this.compraRealizada = procesoCompraFacade.ejecutarProcesoCompra(
-                usuario, eventoId, tipoEntradaNombre, cantidad, detallesPago, codigoDescuento
+                usuario, eventoId, tipoEntradaNombre, cantidad, detallesPago, codigoDescuento,
+                this.aplicarMercancia, this.aplicarDescuento
             );
             return this.compraRealizada != null;
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/eventmaster/model/facade/ProcesoCompraFacade.java
+++ b/src/main/java/com/eventmaster/model/facade/ProcesoCompraFacade.java
@@ -86,7 +86,8 @@ public class ProcesoCompraFacade {
         if (aplicarDescuento && tipoEntradaDef.isOfreceDescuentoOpcional()) {
             // Aquí se podría añadir lógica para verificar límites de uso del descuento si existieran
             precioUnitarioCalculado -= tipoEntradaDef.getMontoDescuentoFijo();
-            descripcionEntradaDecorada += " (Descuento: " + tipoEntradaDef.getDescripcionDescuento() + " aplicado)";
+            // Corregido: usar getDescripcionDescuento()
+            descripcionEntradaDecorada += " (Descuento: " + (tipoEntradaDef.getDescripcionDescuento() != null ? tipoEntradaDef.getDescripcionDescuento() : "Promocional") + " aplicado)";
             System.out.println("ProcesoCompraFacade: Descuento aplicado. Nuevo precio unitario: " + precioUnitarioCalculado);
         }
         if (precioUnitarioCalculado < 0) {
@@ -162,7 +163,7 @@ public class ProcesoCompraFacade {
             if (aplicarDescuento && tipoEntradaDef.isOfreceDescuentoOpcional()) {
                 entradaDecorada = new com.eventmaster.model.pattern.decorator.EntradaConDescuento(
                     entradaDecorada,
-                    tipoEntradaDef.getDescripcionDescuento(),
+                    (tipoEntradaDef.getDescripcionDescuento() != null ? tipoEntradaDef.getDescripcionDescuento() : "Descuento Aplicado"), // Corregido y con fallback
                     tipoEntradaDef.getMontoDescuentoFijo()
                 );
             }


### PR DESCRIPTION
He corregido dos errores relacionados con la implementación de decoradores de entrada:
1. ProcesoCompraFacade: Me he asegurado del uso correcto de `getDescripcionDescuento()` desde TipoEntrada y he añadido manejo de nulos para la descripción.
2. ComprarEntradaCommand: He actualizado el constructor y la llamada a `ProcesoCompraFacade.ejecutarProcesoCompra` para incluir los parámetros booleanos `aplicarMercancia` y `aplicarDescuento`, manteniendo la consistencia de la firma del método aunque el comando no esté actualmente en uso en el flujo principal.