### PR TITLE
Fix: Corrected date formatting in confirmarCompra.jsp

### DIFF
--- a/src/main/java/com/eventmaster/controller/CompraServlet.java
+++ b/src/main/java/com/eventmaster/controller/CompraServlet.java
@@ -246,6 +246,15 @@ public class CompraServlet extends HttpServlet {
 
         request.setAttribute("totalProvisional", precioUnitarioConDecoradores * cantidad);
 
+        // Convertir LocalDateTime a java.util.Date para JSTL fmt:formatDate
+        if (eventoParaConfirmar.getFechaHora() != null) {
+            java.util.Date fechaUtilParaJsp = java.util.Date.from(
+                eventoParaConfirmar.getFechaHora().atZone(java.time.ZoneId.systemDefault()).toInstant()
+            );
+            request.setAttribute("fechaHoraDelEventoParaFormatear", fechaUtilParaJsp);
+        } else {
+            request.setAttribute("fechaHoraDelEventoParaFormatear", null);
+        }
 
         RequestDispatcher dispatcher = request.getRequestDispatcher("/jsp/compra/confirmarCompra.jsp");
         dispatcher.forward(request, response);

--- a/src/main/webapp/WEB-INF/jsp/compra/confirmarCompra.jsp
+++ b/src/main/webapp/WEB-INF/jsp/compra/confirmarCompra.jsp
@@ -29,7 +29,12 @@
         <c:if test="${not empty evento && not empty tipoEntradaNombre && not empty cantidad && not empty precioUnitario}">
             <h3>Resumen del Pedido:</h3>
             <p><strong>Evento:</strong> ${evento.nombre}</p>
-            <p><strong>Fecha:</strong> <fmt:formatDate value="${evento.fechaHora}" type="BOTH" dateStyle="medium" timeStyle="short"/></p>
+            <c:if test="${not empty fechaHoraDelEventoParaFormatear}">
+                <p><strong>Fecha:</strong> <fmt:formatDate value="${fechaHoraDelEventoParaFormatear}" type="BOTH" dateStyle="medium" timeStyle="short"/></p>
+            </c:if>
+            <c:if test="${empty fechaHoraDelEventoParaFormatear && not empty evento.fechaHora}">
+                 <p><strong>Fecha:</strong> <c:out value="${evento.fechaHora}"/> (Error al formatear, mostrando valor crudo)</p>
+            </c:if>
             <p><strong>Lugar:</strong> ${evento.lugar.nombre}</p>
             <hr/>
             <p><strong>Tipo de Entrada:</strong> ${tipoEntradaNombre}</p>


### PR DESCRIPTION
This resolves an ELException caused by <fmt:formatDate> attempting to directly convert LocalDateTime to java.util.Date.

Changes:
- CompraServlet#mostrarPaginaConfirmacion: Explicitly converts evento.fechaHora (LocalDateTime) to java.util.Date before passing it to the JSP. The 'totalProvisional' calculation on this page has also been improved.
- confirmarCompra.jsp: Updated to use the new java.util.Date attribute with <fmt:formatDate>.
- EventoServlet#procesarCrearEvento: Improved date parsing and added logging to assist in the original debugging.