### PR TITLE
Fix: Eliminar llamada a setter inexistente en EventoServlet

### DIFF
--- a/src/main/java/com/eventmaster/controller/EventoServlet.java
+++ b/src/main/java/com/eventmaster/controller/EventoServlet.java
@@ -592,10 +592,8 @@ private void verDetalleEvento(HttpServletRequest request, HttpServletResponse re
                 new HashMap<>();
 
             // Limpiar el mapa en el objeto eventoAEditar para llenarlo con los datos del formulario.
-            // El EventoService se encargará de la sincronización con el DAO.
-            if (eventoAEditar.getTiposEntradaDisponibles() == null) {
-                 eventoAEditar.setTiposEntradaDisponibles(new HashMap<>()); // Asumiendo setter, o modificar Evento para asegurar que nunca sea null
-            }
+            // Evento.getTiposEntradaDisponibles() está garantizado a no ser null por el constructor/builder del Evento,
+            // y siempre devolverá al menos un mapa vacío.
             eventoAEditar.getTiposEntradaDisponibles().clear();
 
             boolean primerTipoEntradaValidoIngresado = false;


### PR DESCRIPTION
Corregí EventoServlet#procesarEditarEvento para eliminar una llamada a `eventoAEditar.setTiposEntradaDisponibles()` que no existe.

La lógica ahora confía en que el constructor de la clase Evento asegura que el mapa `tiposEntradaDisponibles` siempre está inicializado (al menos como un HashMap vacío), por lo que solo se necesita llamar a `.clear()` en él antes de repoblarlo con los datos del formulario de edición.