### PR TITLE
Fix: Asegurar guardado de Compra en ProcesoCompraFacade

### DIFF
--- a/src/main/java/com/eventmaster/listener/AppContextListener.java
+++ b/src/main/java/com/eventmaster/listener/AppContextListener.java
@@ -92,7 +92,8 @@ public class AppContextListener implements ServletContextListener {
             usuarioService,
             procesadorPago, // Usar la instancia de ProcesadorPago
             notificacionServiceStub, // Usando el stub
-            entradaFactories
+            entradaFactories,
+            compraDAO // Pasar la instancia de CompraDAO
         );
         ctx.setAttribute("procesoCompraFacade", procesoCompraFacade);
 

--- a/src/main/java/com/eventmaster/model/facade/ProcesoCompraFacade.java
+++ b/src/main/java/com/eventmaster/model/facade/ProcesoCompraFacade.java
@@ -186,11 +186,15 @@ public class ProcesoCompraFacade {
         evento.venderEntradas(tipoEntradaNombre, cantidad); // Este método ya actualiza tipoEntradaDef internamente
         eventoService.actualizarEvento(evento); // Guardar cambios en el evento (entradasVendidas)
 
-        // 6. Confirmar Compra
+        // 6. Confirmar y Guardar Compra
         nuevaCompra.setEstadoCompra("COMPLETADA");
         nuevaCompra.setFechaCompra(java.time.LocalDateTime.now()); // Actualizar fecha a la de confirmación
-        usuarioService.agregarCompraAlHistorial(usuario, nuevaCompra);
-        System.out.println("ProcesoCompraFacade: Compra ID " + nuevaCompra.getId() + " completada y registrada.");
+
+        this.compraDAO.save(nuevaCompra); // Guardar la compra en el DAO
+        System.out.println("ProcesoCompraFacade: Compra ID " + nuevaCompra.getId() + " guardada en CompraDAO.");
+
+        usuarioService.agregarCompraAlHistorial(usuario, nuevaCompra); // Esto actualiza el objeto Usuario en memoria
+        System.out.println("ProcesoCompraFacade: Compra ID " + nuevaCompra.getId() + " procesada para historial de usuario.");
 
         // 7. Notificar al Usuario
         notificacionService.enviarConfirmacionCompra(usuario, nuevaCompra);


### PR DESCRIPTION
Se corrige un error donde las compras no se guardaban en el CompraDAO, lo que resultaba en que tu historial de compras ('Mis Entradas') apareciera vacío.

Cambios:
- ProcesoCompraFacade.java: Se inyecta CompraDAO y se llama a compraDAO.save() después de que una compra se completa exitosamente y antes de actualizar tu historial.
- AppContextListener.java: Se actualiza la instanciación de ProcesoCompraFacade para pasarle la dependencia de CompraDAO.