### PR TITLE
Integrate MySQL database for data persistence

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,172 @@
+-- Database Schema for EventMaster Project (MySQL)
+
+-- Usuario Table
+-- Stores both Asistente and Organizador, differentiated by tipo_usuario
+CREATE TABLE IF NOT EXISTS `usuario` (
+    `id` VARCHAR(255) PRIMARY KEY,
+    `nombre` VARCHAR(255) NOT NULL,
+    `email` VARCHAR(255) NOT NULL UNIQUE,
+    `password` VARCHAR(255) NOT NULL, -- NB: Store hashed passwords in a real application!
+    `tipo_usuario` VARCHAR(50) NOT NULL -- e.g., 'ASISTENTE', 'ORGANIZADOR'
+    -- Preferences for Usuario would likely be in a separate join table (e.g., usuario_preferencias)
+    -- HistorialCompras is derived from the Compra table
+);
+
+-- Lugar Table
+CREATE TABLE IF NOT EXISTS `lugar` (
+    `id` VARCHAR(255) PRIMARY KEY,
+    `nombre` VARCHAR(255) NOT NULL,
+    `direccion` TEXT,
+    -- For complex fields like tiposEventosAdmitidos, reservasPorFranja, subcomponentes:
+    -- These are not fully handled by the basic LugarDAOImplMySQL.
+    -- Option 1: JSON/TEXT columns (shown here as placeholders, querying is difficult)
+    `tipos_eventos_admitidos` TEXT, -- Placeholder for JSON array of strings
+    `reservas_por_franja` TEXT,     -- Placeholder for JSON map
+    -- Option 2: Separate normalized tables (preferred for relational integrity and querying)
+    -- e.g., lugar_tipos_eventos (lugar_id, tipo_evento_str)
+    -- e.g., lugar_subcomponentes (parent_lugar_id, child_component_id, component_type)
+    -- Capacidad total is often derived from subcomponentes or defined directly.
+    -- If a Lugar itself has a base capacity not from subcomponents, add a capacity column here.
+    `capacidad_base` INT DEFAULT 0
+);
+-- Example for subcomponentes if Lugar can contain other Lugares (simplified hierarchical)
+-- ALTER TABLE `lugar` ADD COLUMN `parent_lugar_id` VARCHAR(255) NULL;
+-- ALTER TABLE `lugar` ADD CONSTRAINT `fk_lugar_parent` FOREIGN KEY (`parent_lugar_id`) REFERENCES `lugar` (`id`) ON DELETE SET NULL;
+
+
+-- Evento Table
+CREATE TABLE IF NOT EXISTS `evento` (
+    `id` VARCHAR(255) PRIMARY KEY,
+    `nombre` VARCHAR(255) NOT NULL,
+    `descripcion` TEXT,
+    `categoria` VARCHAR(100),
+    `fecha_hora` DATETIME NOT NULL,
+    `lugar_id` VARCHAR(255) NOT NULL,
+    `organizador_id` VARCHAR(255) NOT NULL,
+    `capacidad_total` INT DEFAULT 0,
+    `entradas_vendidas` INT DEFAULT 0,
+    `estado_actual` VARCHAR(50) NOT NULL, -- e.g., "BORRADOR", "PUBLICADO", "CANCELADO", "EN_CURSO", "FINALIZADO"
+    -- urlsImagenes, urlsVideos, tiposEntradaDisponibles would typically be in related tables
+    -- e.g., evento_imagenes (evento_id, image_url)
+    -- e.g., evento_videos (evento_id, video_url)
+    -- Tipos de entrada definitions are in tipo_entrada_definicion table
+    FOREIGN KEY (`lugar_id`) REFERENCES `lugar` (`id`) ON DELETE RESTRICT,
+    FOREIGN KEY (`organizador_id`) REFERENCES `usuario` (`id`) ON DELETE RESTRICT -- Organizador must be a Usuario
+);
+
+-- TipoEntradaDefinicion Table (Defines the types of tickets available for an event)
+CREATE TABLE IF NOT EXISTS `tipo_entrada_definicion` (
+    `id` VARCHAR(255) PRIMARY KEY, -- Unique ID for this specific definition instance
+    `evento_id` VARCHAR(255) NOT NULL,
+    `nombre_tipo` VARCHAR(100) NOT NULL, -- e.g., "General", "VIP"
+    `precio_base` DECIMAL(10, 2) NOT NULL,
+    `cantidad_total` INT NOT NULL,
+    `cantidad_disponible` INT NOT NULL,
+    `limite_compra_por_usuario` INT DEFAULT 1000, -- Or some other high number for effectively no limit
+    `beneficios_extra` TEXT, -- Placeholder for JSON array of strings
+
+    -- Decorator related fields from TipoEntrada model
+    `ofrece_mercancia` BOOLEAN DEFAULT FALSE,
+    `desc_mercancia` VARCHAR(255),
+    `precio_mercancia` DECIMAL(10, 2) DEFAULT 0.00,
+    `ofrece_descuento` BOOLEAN DEFAULT FALSE,
+    `desc_descuento` VARCHAR(255),
+    `monto_descuento` DECIMAL(10, 2) DEFAULT 0.00,
+
+    FOREIGN KEY (`evento_id`) REFERENCES `evento` (`id`) ON DELETE CASCADE,
+    UNIQUE KEY `uq_evento_nombretipo` (`evento_id`, `nombre_tipo`) -- A ticket type name should be unique within an event
+);
+
+-- Compra Table
+CREATE TABLE IF NOT EXISTS `compra` (
+    `id` VARCHAR(255) PRIMARY KEY,
+    `usuario_id` VARCHAR(255) NOT NULL,
+    `evento_id` VARCHAR(255) NOT NULL, -- The primary event of the purchase (denormalized for easy query, or could be derived from entradas)
+    `total_pagado` DECIMAL(10, 2) NOT NULL,
+    `fecha_compra` DATETIME NOT NULL,
+    `estado_compra` VARCHAR(50) NOT NULL, -- e.g., "PENDIENTE_PAGO", "COMPLETADA", "CANCELADA"
+    `id_transaccion_pasarela` VARCHAR(255),
+    FOREIGN KEY (`usuario_id`) REFERENCES `usuario` (`id`) ON DELETE RESTRICT,
+    FOREIGN KEY (`evento_id`) REFERENCES `evento` (`id`) ON DELETE RESTRICT
+    -- HistorialOperaciones (Commands) would be complex to store relationally; maybe a separate log table or serialized.
+);
+
+-- EntradaVendida Table (Individual sold tickets)
+CREATE TABLE IF NOT EXISTS `entrada_vendida` (
+    `id` VARCHAR(255) PRIMARY KEY, -- Unique ID for this specific sold ticket instance
+    `evento_id` VARCHAR(255) NOT NULL,
+    `compra_id` VARCHAR(255), -- Nullable if an entry can exist outside a direct purchase (e.g. complimentary)
+                                -- Or NOT NULL if every ticket *must* belong to a purchase.
+    -- `tipo_entrada_definicion_id` VARCHAR(255) NOT NULL, -- FK to tipo_entrada_definicion.id
+    `tipo_entrada_nombre` VARCHAR(100) NOT NULL, -- Denormalized name of the type (e.g. "VIP") for convenience
+    `precio_final` DECIMAL(10, 2) NOT NULL, -- Actual price paid for this ticket
+    `descripcion_final` TEXT, -- Final description (e.g., including decorator info)
+    -- Could add other fields like qr_code_data, check_in_status, etc.
+    FOREIGN KEY (`evento_id`) REFERENCES `evento` (`id`) ON DELETE CASCADE,
+    FOREIGN KEY (`compra_id`) REFERENCES `compra` (`id`) ON DELETE SET NULL -- Or CASCADE if entries are deleted with compra
+    -- FOREIGN KEY (`tipo_entrada_definicion_id`) REFERENCES `tipo_entrada_definicion` (`id`) ON DELETE RESTRICT
+);
+
+
+-- Promocion Table
+CREATE TABLE IF NOT EXISTS `promocion` (
+    `id` VARCHAR(255) PRIMARY KEY,
+    `descripcion` VARCHAR(255) NOT NULL,
+    `porcentaje_descuento` DECIMAL(5, 4) NOT NULL, -- e.g., 0.1000 for 10.00%
+    `fecha_inicio` DATETIME NOT NULL,
+    `fecha_fin` DATETIME NOT NULL,
+    `tipo_aplicable` VARCHAR(50), -- "Evento", "TipoEntrada", "UsuarioEspecifico"
+    `id_aplicable` VARCHAR(255)   -- EventoID, TipoEntradaDefinicionID (or nombre_tipo if unique enough), UsuarioID
+);
+
+-- CodigoDescuento Table
+CREATE TABLE IF NOT EXISTS `codigo_descuento` (
+    `codigo_str` VARCHAR(100) PRIMARY KEY, -- The literal code string users enter
+    `porcentaje_descuento` DECIMAL(5, 4) NOT NULL,
+    `fecha_expiracion` DATETIME,
+    `usos_maximos` INT DEFAULT 1,
+    `usos_actuales` INT DEFAULT 0,
+    `activo` BOOLEAN DEFAULT TRUE,
+    `promocion_asociada_id` VARCHAR(255), -- Optional FK to Promocion table
+    FOREIGN KEY (`promocion_asociada_id`) REFERENCES `promocion` (`id`) ON DELETE SET NULL
+);
+
+-- --- Potentially missing tables for complex relationships / features: ---
+
+-- `usuario_preferencias` (usuario_id, preferencia_tag_o_categoria_id)
+-- `evento_imagenes` (id, evento_id, image_url, es_principal)
+-- `evento_videos` (id, evento_id, video_url)
+-- `lugar_secciones` (id, lugar_id, nombre_seccion, capacidad_seccion) if using Composite for Lugar in DB
+-- `compra_historial_operaciones` (id, compra_id, comando_nombre, comando_data_json, timestamp)
+
+-- --- Indexes for Performance (examples) ---
+CREATE INDEX idx_usuario_email ON usuario(email);
+CREATE INDEX idx_evento_fecha ON evento(fecha_hora);
+CREATE INDEX idx_evento_lugar ON evento(lugar_id);
+CREATE INDEX idx_evento_organizador ON evento(organizador_id);
+CREATE INDEX idx_tipo_entrada_evento ON tipo_entrada_definicion(evento_id);
+CREATE INDEX idx_compra_usuario ON compra(usuario_id);
+CREATE INDEX idx_compra_evento ON compra(evento_id);
+CREATE INDEX idx_entrada_vendida_evento ON entrada_vendida(evento_id);
+CREATE INDEX idx_entrada_vendida_compra ON entrada_vendida(compra_id);
+CREATE INDEX idx_promocion_fechas ON promocion(fecha_inicio, fecha_fin);
+CREATE INDEX idx_codigo_descuento_activo_fecha ON codigo_descuento(activo, fecha_expiracion);
+
+/*
+Notas sobre el esquema:
+1.  IDs: VARCHAR(255) is used for UUIDs. If using auto-increment integers, change type to INT AUTO_INCREMENT.
+2.  Password Hashing: `usuario.password` MUST store hashed passwords.
+3.  Complex Fields in Lugar: `tipos_eventos_admitidos` and `reservas_por_franja` are TEXT placeholders.
+    A normalized approach with separate tables is generally better for querying and integrity.
+    The Composite pattern for Lugar (subcomponentes) is also not fully represented here; it would likely need
+    an adjacency list or nested set model if sub-Lugar components are also stored in the `lugar` table
+    or a separate `lugar_componente` table.
+4.  `entrada_vendida.tipo_entrada_definicion_id`: Commented out, but would be a good FK to link a sold ticket
+    back to its definition, rather than just relying on `tipo_entrada_nombre`.
+5.  `compra.evento_id`: This is somewhat denormalized if a Compra is primarily a collection of Entradas from the
+    same Evento. It's kept for simplicity as per the Compra model.
+6.  Cascade/Restrict: FK constraints use ON DELETE RESTRICT or ON DELETE SET NULL/CASCADE based on common scenarios.
+    Review these based on specific business rules (e.g., what happens if an Evento is deleted?).
+7.  Timestamps: DATETIME is used. Consider TIMESTAMP if UTC storage and automatic timezone conversion are desired.
+8.  Precision for DECIMAL: Adjust precision (10,2) or (5,4) as needed for monetary values and percentages.
+*/

--- a/src/main/java/com/eventmaster/dao/impl/mysql/CodigoDescuentoDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/CodigoDescuentoDAOImplMySQL.java
@@ -1,0 +1,255 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.CodigoDescuentoDAO;
+import com.eventmaster.dao.PromocionDAO; // For fetching PromocionAsociada
+import com.eventmaster.model.CodigoDescuento;
+import com.eventmaster.model.Promocion;
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+// CodigoDescuento model does not have an 'id' field, it uses 'codigo' string as its primary identifier.
+// The DAO interface has findById, implying an internal ID might exist in DB.
+// For this implementation, we'll assume 'codigo' (the string) is the PK in the DB table.
+// If a separate UUID-based 'id' column is also present in DB, queries would need adjustment.
+
+public class CodigoDescuentoDAOImplMySQL implements CodigoDescuentoDAO {
+
+    // Table and column names
+    private static final String TABLE_CODIGO_DESCUENTO = "codigo_descuento";
+    // Assuming 'codigo_str' is the primary key string that users enter.
+    // If there's also an internal auto-increment or UUID 'id', that needs to be added.
+    // For now, 'codigo_str' is the main identifier from the model.
+    private static final String COLUMN_CODIGO_STR = "codigo_str"; // The literal code string
+    private static final String COLUMN_PORCENTAJE_DESCUENTO = "porcentaje_descuento";
+    private static final String COLUMN_FECHA_EXPIRACION = "fecha_expiracion";
+    private static final String COLUMN_USOS_MAXIMOS = "usos_maximos";
+    private static final String COLUMN_USOS_ACTUALES = "usos_actuales";
+    private static final String COLUMN_ACTIVO = "activo";
+    private static final String COLUMN_PROMOCION_ASOCIADA_ID = "promocion_asociada_id"; // FK to Promocion table
+
+    private PromocionDAO promocionDAO; // For fetching PromocionAsociada
+
+    public CodigoDescuentoDAOImplMySQL(PromocionDAO promocionDAO) {
+        this.promocionDAO = promocionDAO;
+    }
+    public CodigoDescuentoDAOImplMySQL() {
+        // Default constructor, promocionDAO to be set via setter
+    }
+    public void setPromocionDAO(PromocionDAO promocionDAO) {
+        this.promocionDAO = promocionDAO;
+    }
+
+
+    // SQL Queries
+    // Using 'codigo_str' as the key from model.
+    private static final String INSERT_CODIGO_DESCUENTO = "INSERT INTO " + TABLE_CODIGO_DESCUENTO +
+            "(" + COLUMN_CODIGO_STR + ", " + COLUMN_PORCENTAJE_DESCUENTO + ", " + COLUMN_FECHA_EXPIRACION + ", " +
+            COLUMN_USOS_MAXIMOS + ", " + COLUMN_USOS_ACTUALES + ", " + COLUMN_ACTIVO + ", " + COLUMN_PROMOCION_ASOCIADA_ID +
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_CODIGO_STR = "SELECT * FROM " + TABLE_CODIGO_DESCUENTO + " WHERE " + COLUMN_CODIGO_STR + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_CODIGO_DESCUENTO;
+    private static final String SELECT_ALL_ACTIVOS = "SELECT * FROM " + TABLE_CODIGO_DESCUENTO +
+            " WHERE " + COLUMN_ACTIVO + " = TRUE AND (" + COLUMN_FECHA_EXPIRACION + " IS NULL OR " + COLUMN_FECHA_EXPIRACION + " >= ?) AND " +
+            COLUMN_USOS_ACTUALES + " < " + COLUMN_USOS_MAXIMOS;
+
+    private static final String UPDATE_CODIGO_DESCUENTO = "UPDATE " + TABLE_CODIGO_DESCUENTO + " SET " +
+            COLUMN_PORCENTAJE_DESCUENTO + " = ?, " + COLUMN_FECHA_EXPIRACION + " = ?, " +
+            COLUMN_USOS_MAXIMOS + " = ?, " + COLUMN_USOS_ACTUALES + " = ?, " + COLUMN_ACTIVO + " = ?, " +
+            COLUMN_PROMOCION_ASOCIADA_ID + " = ? " +
+            "WHERE " + COLUMN_CODIGO_STR + " = ?";
+
+    private static final String DELETE_BY_CODIGO_STR = "DELETE FROM " + TABLE_CODIGO_DESCUENTO + " WHERE " + COLUMN_CODIGO_STR + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_CODIGO_DESCUENTO;
+
+
+    @Override
+    public Optional<CodigoDescuento> findByCodigo(String codigo) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_CODIGO_STR)) {
+            stmt.setString(1, codigo);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToCodigoDescuento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding CodigoDescuento by codigo_str: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The CodigoDescuento model uses the 'codigo' string as its main identifier.
+     * If 'id' in the DAO interface refers to this string, then this method is equivalent to findByCodigo.
+     * If 'id' refers to a separate internal DB ID (e.g., UUID or auto-increment), this method needs
+     * a different query and the table needs an 'id' column.
+     * For this implementation, assuming 'id' refers to the 'codigo' string.
+     */
+    @Override
+    public Optional<CodigoDescuento> findById(String id) {
+        return findByCodigo(id);
+    }
+
+    @Override
+    public List<CodigoDescuento> findAll() {
+        List<CodigoDescuento> codigos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                codigos.add(mapRowToCodigoDescuento(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all CodigoDescuentos: " + e.getMessage());
+        }
+        return codigos;
+    }
+
+    @Override
+    public List<CodigoDescuento> findAllActivos() {
+        List<CodigoDescuento> codigos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL_ACTIVOS)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(LocalDateTime.now()));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    codigos.add(mapRowToCodigoDescuento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding active CodigoDescuentos: " + e.getMessage());
+        }
+        return codigos;
+    }
+
+    @Override
+    public CodigoDescuento save(CodigoDescuento codigoDescuento) {
+        // Assumes 'codigo' (the string) is the primary key and unique.
+        // Insert or Update logic based on existence of 'codigoDescuento.getCodigo()'
+        Optional<CodigoDescuento> existing = findByCodigo(codigoDescuento.getCodigo());
+        boolean isNew = !existing.isPresent();
+
+        String sql = isNew ? INSERT_CODIGO_DESCUENTO : UPDATE_CODIGO_DESCUENTO;
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            String promocionId = null;
+            if (codigoDescuento.getPromocionAsociada() != null) {
+                promocionId = codigoDescuento.getPromocionAsociada().getId();
+            }
+
+            if (isNew) {
+                stmt.setString(1, codigoDescuento.getCodigo());
+                stmt.setDouble(2, codigoDescuento.getPorcentajeDescuento());
+                stmt.setTimestamp(3, codigoDescuento.getFechaExpiracion() != null ? Timestamp.valueOf(codigoDescuento.getFechaExpiracion()) : null);
+                stmt.setInt(4, codigoDescuento.getUsosMaximos());
+                stmt.setInt(5, codigoDescuento.getUsosActuales());
+                stmt.setBoolean(6, codigoDescuento.isActivo());
+                stmt.setString(7, promocionId);
+            } else { // Update
+                stmt.setDouble(1, codigoDescuento.getPorcentajeDescuento());
+                stmt.setTimestamp(2, codigoDescuento.getFechaExpiracion() != null ? Timestamp.valueOf(codigoDescuento.getFechaExpiracion()) : null);
+                stmt.setInt(3, codigoDescuento.getUsosMaximos());
+                stmt.setInt(4, codigoDescuento.getUsosActuales());
+                stmt.setBoolean(5, codigoDescuento.isActivo());
+                stmt.setString(6, promocionId);
+                stmt.setString(7, codigoDescuento.getCodigo()); // WHERE codigo_str = ?
+            }
+            stmt.executeUpdate();
+            return codigoDescuento;
+        } catch (SQLException e) {
+            System.err.println("Error saving CodigoDescuento: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public void deleteById(String id) {
+        // Assuming 'id' is the 'codigo' string.
+        deleteByCodigo(id);
+    }
+
+    @Override
+    public void deleteByCodigo(String codigo) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_CODIGO_STR)) {
+            stmt.setString(1, codigo);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting CodigoDescuento by codigo_str: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting all CodigoDescuentos: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private CodigoDescuento mapRowToCodigoDescuento(ResultSet rs) throws SQLException {
+        String codigoStr = rs.getString(COLUMN_CODIGO_STR);
+        double porcentajeDescuento = rs.getDouble(COLUMN_PORCENTAJE_DESCUENTO);
+        Timestamp fechaExpiracionTS = rs.getTimestamp(COLUMN_FECHA_EXPIRACION);
+        LocalDateTime fechaExpiracion = (fechaExpiracionTS != null) ? fechaExpiracionTS.toLocalDateTime() : null;
+        int usosMaximos = rs.getInt(COLUMN_USOS_MAXIMOS);
+        int usosActuales = rs.getInt(COLUMN_USOS_ACTUALES);
+        boolean activo = rs.getBoolean(COLUMN_ACTIVO);
+        String promocionId = rs.getString(COLUMN_PROMOCION_ASOCIADA_ID);
+
+        CodigoDescuento codigoDescuento = new CodigoDescuento(codigoStr, porcentajeDescuento, fechaExpiracion, usosMaximos);
+        // Model constructor initializes usosActuales to 0 and activo to true.
+        // We need to set them from DB values.
+        try {
+            // Reflection or dedicated setters would be cleaner.
+            // For now, direct field manipulation or simple setters if they existed.
+            // Let's assume CodigoDescuento needs setters for these for ORM.
+            // Or, the constructor needs to be more flexible.
+            // To avoid modifying model now, we'll set what we can.
+            // A simple way for usosActuales:
+            for(int i=0; i < usosActuales; i++) {
+                codigoDescuento.incrementarUso(); // This also handles deactivating if max uses reached
+            }
+            // If 'activo' from DB is false, and incrementing uses didn't make it false, set it.
+            if (!activo && codigoDescuento.isActivo()) {
+                 codigoDescuento.setActivo(false);
+            }
+            // This way of setting usosActuales is not ideal as `incrementarUso` might have side effects.
+            // A direct setter `setUsosActuales(int n)` would be better.
+            // For now, the above is a workaround.
+
+        } catch (Exception e) {
+            // Should not happen with current model, but good practice if reflection were used.
+            System.err.println("Error setting usosActuales/activo reflectively: " + e.getMessage());
+        }
+        // Correctly set 'activo' state from DB if it differs from calculated
+        if (codigoDescuento.isActivo() != activo) {
+            codigoDescuento.setActivo(activo);
+        }
+
+
+        if (promocionId != null && this.promocionDAO != null) {
+            Optional<Promocion> promoOpt = this.promocionDAO.findById(promocionId);
+            promoOpt.ifPresent(codigoDescuento::setPromocionAsociada);
+            // If promoOpt is empty, promocionAsociada remains null, which is fine.
+        } else if (promocionId != null && this.promocionDAO == null) {
+            System.err.println("Warning: PromocionDAO not injected in CodigoDescuentoDAOImplMySQL. Cannot fetch PromocionAsociada for ID: " + promocionId);
+        }
+
+
+        return codigoDescuento;
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/CompraDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/CompraDAOImplMySQL.java
@@ -1,0 +1,343 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.CompraDAO;
+import com.eventmaster.dao.UsuarioDAO; // To fetch Usuario
+import com.eventmaster.dao.EventoDAO;  // To fetch Evento
+// EntradaDAO might be needed if we were to save/load Entrada instances as part of Compra persistence
+// However, Compra.entradasCompradas is a List<Entrada>. Individual Entrada instances are saved by EntradaDAO.
+// This CompraDAO will store compra metadata. The link between Compra and its Entradas is via Compra_ID on Entrada table.
+import com.eventmaster.model.entity.Compra;
+import com.eventmaster.model.entity.Usuario;
+import com.eventmaster.model.entity.Evento;
+// import com.eventmaster.model.pattern.factory.Entrada; // Not directly mapped here, but related
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class CompraDAOImplMySQL implements CompraDAO {
+
+    // Table and column names
+    private static final String TABLE_COMPRA = "compra";
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_USUARIO_ID = "usuario_id";
+    private static final String COLUMN_EVENTO_ID = "evento_id"; // Evento primarily associated with the purchase
+    private static final String COLUMN_TOTAL_PAGADO = "total_pagado";
+    private static final String COLUMN_FECHA_COMPRA = "fecha_compra";
+    private static final String COLUMN_ESTADO_COMPRA = "estado_compra";
+    private static final String COLUMN_ID_TRANSACCION_PASARELA = "id_transaccion_pasarela";
+
+    // DAOs for related entities
+    private UsuarioDAO usuarioDAO;
+    private EventoDAO eventoDAO;
+    // private EntradaDAO entradaDAO; // Needed if loading entradasCompradas list here
+
+    // Constructor for dependency injection
+    public CompraDAOImplMySQL(UsuarioDAO usuarioDAO, EventoDAO eventoDAO) {
+        this.usuarioDAO = usuarioDAO;
+        this.eventoDAO = eventoDAO;
+    }
+     public CompraDAOImplMySQL() {
+        // Default constructor, dependencies to be set via setters
+    }
+
+    public void setUsuarioDAO(UsuarioDAO usuarioDAO) {
+        this.usuarioDAO = usuarioDAO;
+    }
+
+    public void setEventoDAO(EventoDAO eventoDAO) {
+        this.eventoDAO = eventoDAO;
+    }
+
+    // SQL Queries
+    private static final String INSERT_COMPRA = "INSERT INTO " + TABLE_COMPRA +
+            "(" + COLUMN_ID + ", " + COLUMN_USUARIO_ID + ", " + COLUMN_EVENTO_ID + ", " + COLUMN_TOTAL_PAGADO + ", " +
+            COLUMN_FECHA_COMPRA + ", " + COLUMN_ESTADO_COMPRA + ", " + COLUMN_ID_TRANSACCION_PASARELA +
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_COMPRA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_COMPRA;
+    private static final String SELECT_BY_USUARIO_ID = "SELECT * FROM " + TABLE_COMPRA + " WHERE " + COLUMN_USUARIO_ID + " = ?";
+    private static final String SELECT_BY_EVENTO_ID = "SELECT * FROM " + TABLE_COMPRA + " WHERE " + COLUMN_EVENTO_ID + " = ?"; // For finding all purchases related to one event
+    private static final String SELECT_BY_FECHA_BETWEEN = "SELECT * FROM " + TABLE_COMPRA + " WHERE " + COLUMN_FECHA_COMPRA + " BETWEEN ? AND ?";
+    private static final String SELECT_BY_ESTADO = "SELECT * FROM " + TABLE_COMPRA + " WHERE " + COLUMN_ESTADO_COMPRA + " = ?";
+
+    private static final String UPDATE_COMPRA = "UPDATE " + TABLE_COMPRA + " SET " +
+            COLUMN_USUARIO_ID + " = ?, " + COLUMN_EVENTO_ID + " = ?, " + COLUMN_TOTAL_PAGADO + " = ?, " +
+            COLUMN_FECHA_COMPRA + " = ?, " + COLUMN_ESTADO_COMPRA + " = ?, " + COLUMN_ID_TRANSACCION_PASARELA + " = ? " +
+            "WHERE " + COLUMN_ID + " = ?";
+
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_COMPRA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_COMPRA;
+    private static final String COUNT_BY_USUARIO_ID = "SELECT COUNT(*) FROM " + TABLE_COMPRA + " WHERE " + COLUMN_USUARIO_ID + " = ?";
+    private static final String COUNT_BY_EVENTO_ID = "SELECT COUNT(*) FROM " + TABLE_COMPRA + " WHERE " + COLUMN_EVENTO_ID + " = ?";
+
+
+    @Override
+    public Optional<Compra> findById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToCompra(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Compra by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Compra> findAll() {
+        List<Compra> compras = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                compras.add(mapRowToCompra(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all Compras: " + e.getMessage());
+        }
+        return compras;
+    }
+
+    @Override
+    public List<Compra> findByUsuario(Usuario usuario) {
+        if (usuario == null || usuario.getId() == null) return new ArrayList<>();
+        return findByUsuarioId(usuario.getId());
+    }
+
+    @Override
+    public List<Compra> findByUsuarioId(String usuarioId) {
+        List<Compra> compras = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_USUARIO_ID)) {
+            stmt.setString(1, usuarioId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    compras.add(mapRowToCompra(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Compras by UsuarioID: " + e.getMessage());
+        }
+        return compras;
+    }
+
+    @Override
+    public List<Compra> findByEvento(Evento evento) {
+        if (evento == null || evento.getId() == null) return new ArrayList<>();
+        return findByEventoId(evento.getId());
+    }
+
+    @Override
+    public List<Compra> findByEventoId(String eventoId) {
+        List<Compra> compras = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_EVENTO_ID)) {
+            stmt.setString(1, eventoId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    compras.add(mapRowToCompra(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Compras by EventoID: " + e.getMessage());
+        }
+        return compras;
+    }
+
+    @Override
+    public List<Compra> findByFechaCompraBetween(LocalDateTime inicio, LocalDateTime fin) {
+        List<Compra> compras = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_FECHA_BETWEEN)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(inicio));
+            stmt.setTimestamp(2, Timestamp.valueOf(fin));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    compras.add(mapRowToCompra(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Compras by fecha: " + e.getMessage());
+        }
+        return compras;
+    }
+
+    @Override
+    public List<Compra> findByEstadoCompra(String estado) {
+        List<Compra> compras = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ESTADO)) {
+            stmt.setString(1, estado);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    compras.add(mapRowToCompra(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Compras by estado: " + e.getMessage());
+        }
+        return compras;
+    }
+
+    @Override
+    public Compra save(Compra compra) {
+        if (compra.getUsuario() == null || compra.getUsuario().getId() == null) {
+             System.err.println("Error: Compra must have a valid Usuario with an ID.");
+             return null;
+        }
+        if (compra.getEvento() == null || compra.getEvento().getId() == null) {
+             System.err.println("Error: Compra must have a valid Evento with an ID.");
+             return null;
+        }
+
+        boolean isNew = compra.getId() == null || findById(compra.getId()).isEmpty();
+        if (isNew && compra.getId() == null) {
+            compra.setId(UUID.randomUUID().toString());
+        }
+
+        String sql = isNew ? INSERT_COMPRA : UPDATE_COMPRA;
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            if (isNew) {
+                stmt.setString(1, compra.getId());
+                stmt.setString(2, compra.getUsuario().getId());
+                stmt.setString(3, compra.getEvento().getId());
+                stmt.setDouble(4, compra.getTotalPagado());
+                stmt.setTimestamp(5, Timestamp.valueOf(compra.getFechaCompra()));
+                stmt.setString(6, compra.getEstadoCompra());
+                stmt.setString(7, compra.getIdTransaccionPasarela());
+            } else { // Update
+                stmt.setString(1, compra.getUsuario().getId());
+                stmt.setString(2, compra.getEvento().getId());
+                stmt.setDouble(3, compra.getTotalPagado());
+                stmt.setTimestamp(4, Timestamp.valueOf(compra.getFechaCompra()));
+                stmt.setString(5, compra.getEstadoCompra());
+                stmt.setString(6, compra.getIdTransaccionPasarela());
+                stmt.setString(7, compra.getId()); // WHERE id = ?
+            }
+            stmt.executeUpdate();
+            // Note: The entradasCompradas list within the Compra object is not persisted by this DAO.
+            // Individual Entrada instances are saved by EntradaDAO and linked via compra_id.
+            return compra;
+        } catch (SQLException e) {
+            System.err.println("Error saving Compra: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public void deleteById(String id) {
+        // Consider implications: deleting a Compra might require deleting associated Entrada records
+        // or handling them based on business rules (e.g., cascade delete in DB or manual deletion via EntradaDAO).
+        // This DAO only deletes the Compra record itself.
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Compra by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void delete(Compra compra) {
+        if (compra != null && compra.getId() != null) {
+            deleteById(compra.getId());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting all Compras: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public long countByUsuarioId(String usuarioId) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_BY_USUARIO_ID)) {
+            stmt.setString(1, usuarioId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Compras by UsuarioID: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public long countByEventoId(String eventoId) {
+         try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_BY_EVENTO_ID)) {
+            stmt.setString(1, eventoId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Compras by EventoID: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private Compra mapRowToCompra(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String usuarioId = rs.getString(COLUMN_USUARIO_ID);
+        String eventoId = rs.getString(COLUMN_EVENTO_ID);
+        double totalPagado = rs.getDouble(COLUMN_TOTAL_PAGADO);
+        LocalDateTime fechaCompra = rs.getTimestamp(COLUMN_FECHA_COMPRA).toLocalDateTime();
+        String estadoCompra = rs.getString(COLUMN_ESTADO_COMPRA);
+        String idTransaccionPasarela = rs.getString(COLUMN_ID_TRANSACCION_PASARELA);
+
+        if (this.usuarioDAO == null || this.eventoDAO == null) {
+            throw new IllegalStateException("UsuarioDAO or EventoDAO not initialized in CompraDAOImplMySQL.");
+        }
+
+        Usuario usuario = usuarioDAO.findById(usuarioId)
+                .orElseThrow(() -> new SQLException("Usuario not found for ID: " + usuarioId + " for Compra ID: " + id));
+        Evento evento = eventoDAO.findById(eventoId)
+                .orElseThrow(() -> new SQLException("Evento not found for ID: " + eventoId + " for Compra ID: " + id));
+
+        Compra compra = new Compra(id, usuario, evento);
+        compra.setTotalPagado(totalPagado);
+        compra.setFechaCompra(fechaCompra);
+        compra.setEstadoCompra(estadoCompra);
+        compra.setIdTransaccionPasarela(idTransaccionPasarela);
+
+        // The list Compra.entradasCompradas is NOT populated here.
+        // To populate it, we would need EntradaDAO and a method like entradaDAO.findAllByCompraId(id).
+        // This is often handled at the service layer to avoid circular dependencies or overly complex DAOs.
+        // For example:
+        // if (this.entradaDAO != null) {
+        //     List<Entrada> entradas = this.entradaDAO.findAllByCompraId(id);
+        //     entradas.forEach(compra::agregarEntrada);
+        // }
+        // The historialOperaciones list is also not populated from the DB by this basic DAO.
+
+        return compra;
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/EntradaDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/EntradaDAOImplMySQL.java
@@ -1,0 +1,284 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.EntradaDAO;
+import com.eventmaster.dao.EventoDAO; // To fetch Evento for EventoAsociado
+import com.eventmaster.model.entity.Evento; // For EventoAsociado
+import com.eventmaster.model.pattern.factory.Entrada;
+// A concrete implementation of Entrada will be needed for instantiation
+import com.eventmaster.model.pattern.factory.impl.EntradaImpl; // Assuming a generic implementation
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class EntradaDAOImplMySQL implements EntradaDAO {
+
+    // Table and column names for sold entries
+    private static final String TABLE_ENTRADA_VENDIDA = "entrada_vendida";
+    private static final String COLUMN_ID = "id"; // Unique ID for this sold entry instance
+    private static final String COLUMN_EVENTO_ID = "evento_id"; // FK to Evento
+    private static final String COLUMN_COMPRA_ID = "compra_id"; // FK to Compra
+    private static final String COLUMN_TIPO_ENTRADA_NOMBRE = "tipo_entrada_nombre"; // e.g., "General", "VIP"
+    private static final String COLUMN_PRECIO_FINAL = "precio_final"; // Price at which it was sold
+    private static final String COLUMN_DESCRIPCION_FINAL = "descripcion_final"; // Description at time of sale (could include decorator info)
+    // We might also need a reference to the TipoEntrada definition ID if applicable:
+    // private static final String COLUMN_TIPO_ENTRADA_DEF_ID = "tipo_entrada_definicion_id";
+
+
+    // SQL Queries
+    private static final String INSERT_ENTRADA = "INSERT INTO " + TABLE_ENTRADA_VENDIDA +
+            "(" + COLUMN_ID + ", " + COLUMN_EVENTO_ID + ", " + COLUMN_COMPRA_ID + ", " + COLUMN_TIPO_ENTRADA_NOMBRE + ", " +
+            COLUMN_PRECIO_FINAL + ", " + COLUMN_DESCRIPCION_FINAL + ") VALUES (?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_ALL_BY_COMPRA_ID = "SELECT * FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_COMPRA_ID + " = ?";
+    private static final String SELECT_ALL_BY_EVENTO_ID = "SELECT * FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_EVENTO_ID + " = ?";
+    private static final String SELECT_ALL_BY_EVENTO_ID_AND_TIPO = "SELECT * FROM " + TABLE_ENTRADA_VENDIDA +
+            " WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_TIPO_ENTRADA_NOMBRE + " = ?";
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String DELETE_ALL_BY_COMPRA_ID = "DELETE FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_COMPRA_ID + " = ?";
+    private static final String COUNT_BY_EVENTO_ID = "SELECT COUNT(*) FROM " + TABLE_ENTRADA_VENDIDA + " WHERE " + COLUMN_EVENTO_ID + " = ?";
+    private static final String COUNT_BY_EVENTO_ID_AND_TIPO = "SELECT COUNT(*) FROM " + TABLE_ENTRADA_VENDIDA +
+            " WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_TIPO_ENTRADA_NOMBRE + " = ?";
+
+    private EventoDAO eventoDAO; // Required to fetch Evento for Entrada.getEventoAsociado()
+
+    // Constructor for dependency injection
+    public EntradaDAOImplMySQL(EventoDAO eventoDAO) {
+        this.eventoDAO = eventoDAO;
+    }
+     public EntradaDAOImplMySQL() {
+        // This constructor might be used by AppContextListener if EventoDAO is set via setter.
+        // Ensure EventoDAO is set before use.
+    }
+
+    public void setEventoDAO(EventoDAO eventoDAO) {
+        this.eventoDAO = eventoDAO;
+    }
+
+
+    @Override
+    public Entrada save(Entrada entrada) {
+        if (entrada.getId() == null) {
+            // If Entrada is an interface, its implementations must provide a way to set ID,
+            // or we assume UUID is generated here and not set back if interface is immutable.
+            // For EntradaImpl, we might need a setId method.
+            // For now, assume ID is generated if not present, but not set back on the passed 'entrada' object
+            // if it's purely an interface. This is problematic.
+            // A better approach: ensure 'entrada' has its ID before calling save, or 'save' returns a new instance.
+            // Let's assume the 'entrada' object should have its ID set by the service layer before calling DAO.
+            if (entrada.getId() == null) {
+                 // This path is risky if the caller expects the ID to be on the original object.
+                 // Let's assume `EntradaImpl` (or whatever concrete class) allows ID to be set,
+                 // or the service layer pre-assigns IDs.
+                 // For this example, we'll proceed as if ID is managed by the caller or is on EntradaImpl.
+                 // If entrada.getId() is null, it implies a new UUID should be used for the DB.
+                 // The `entrada` object itself might not get this new UUID if it's an immutable interface implementation.
+                 System.err.println("Warning: Entrada passed to save() has null ID. A new ID will be used for DB, but may not be reflected in the passed object instance if it's immutable.");
+            }
+        }
+        String entradaId = (entrada.getId() != null) ? entrada.getId() : UUID.randomUUID().toString();
+        String eventoId = (entrada.getEventoAsociado() != null) ? entrada.getEventoAsociado().getId() : null;
+
+        // compraId needs to be on the Entrada object, or passed differently.
+        // The Entrada interface doesn't have getCompraId().
+        // We get it from EntradaImpl if the object is an instance of it.
+        String compraId = null;
+        if (entrada instanceof EntradaImpl) {
+            compraId = ((EntradaImpl) entrada).getCompraId();
+        }
+        if (compraId == null) {
+            // System.err.println("Warning: Compra ID is null for Entrada ID: " + entrada.getId() + ". This might be an issue depending on schema (compra_id nullable or not).");
+            // Allow null compraId to proceed; DB constraint will catch if it's an issue.
+        }
+
+
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(INSERT_ENTRADA)) {
+            stmt.setString(1, entradaId);
+            stmt.setString(2, eventoId);
+            stmt.setString(3, compraId); // This needs to be correctly sourced
+            stmt.setString(4, entrada.getTipo());
+            stmt.setDouble(5, entrada.getPrecio());
+            stmt.setString(6, entrada.getDescripcion());
+
+            stmt.executeUpdate();
+            // If ID was generated here, the original 'entrada' object is not updated.
+            // The caller must be aware or use the returned object if it were a new instance with ID.
+            // Since Entrada is an interface, we return the same instance.
+            return entrada;
+        } catch (SQLException e) {
+            System.err.println("Error saving Entrada: " + e.getMessage());
+            e.printStackTrace();
+            return null; // Or throw custom exception
+        }
+    }
+
+    @Override
+    public List<Entrada> saveAll(List<Entrada> entradas) {
+        // Using a batch update could be more efficient if supported and needed.
+        // For now, iterate and save individually.
+        List<Entrada> savedEntradas = new ArrayList<>();
+        for (Entrada entrada : entradas) {
+            Entrada saved = save(entrada);
+            if (saved != null) {
+                savedEntradas.add(saved);
+            } else {
+                // Handle error for individual save: maybe collect errors or stop.
+                System.err.println("Failed to save one of the entradas in batch for evento: " + (entrada.getEventoAsociado() != null ? entrada.getEventoAsociado().getId() : "N/A"));
+            }
+        }
+        return savedEntradas;
+    }
+
+    @Override
+    public Optional<Entrada> findById(String idEntrada) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, idEntrada);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Entrada by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Entrada> findAllByCompraId(String compraId) {
+        List<Entrada> entradas = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL_BY_COMPRA_ID)) {
+            stmt.setString(1, compraId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    entradas.add(mapRowToEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Entradas by CompraID: " + e.getMessage());
+        }
+        return entradas;
+    }
+
+    @Override
+    public List<Entrada> findAllByEventoId(String eventoId) {
+        List<Entrada> entradas = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL_BY_EVENTO_ID)) {
+            stmt.setString(1, eventoId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    entradas.add(mapRowToEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Entradas by EventoID: " + e.getMessage());
+        }
+        return entradas;
+    }
+
+    @Override
+    public List<Entrada> findAllByEventoIdAndTipoEntrada(String eventoId, String nombreTipoEntrada) {
+        List<Entrada> entradas = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL_BY_EVENTO_ID_AND_TIPO)) {
+            stmt.setString(1, eventoId);
+            stmt.setString(2, nombreTipoEntrada);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    entradas.add(mapRowToEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Entradas by EventoID and Tipo: " + e.getMessage());
+        }
+        return entradas;
+    }
+
+    @Override
+    public void deleteById(String idEntrada) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, idEntrada);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Entrada by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteAllByCompraId(String compraId) {
+         try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_ALL_BY_COMPRA_ID)) {
+            stmt.setString(1, compraId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Entradas by CompraID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public long countByEventoId(String eventoId) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_BY_EVENTO_ID)) {
+            stmt.setString(1, eventoId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Entradas by EventoID: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public long countByEventoIdAndTipoEntrada(String eventoId, String nombreTipoEntrada) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_BY_EVENTO_ID_AND_TIPO)) {
+            stmt.setString(1, eventoId);
+            stmt.setString(2, nombreTipoEntrada);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong(1);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Entradas by EventoID and Tipo: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private Entrada mapRowToEntrada(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String eventoId = rs.getString(COLUMN_EVENTO_ID);
+        // String compraId = rs.getString(COLUMN_COMPRA_ID); // Needed if EntradaImpl stores it
+        String tipoEntradaNombre = rs.getString(COLUMN_TIPO_ENTRADA_NOMBRE);
+        double precioFinal = rs.getDouble(COLUMN_PRECIO_FINAL);
+        String descripcionFinal = rs.getString(COLUMN_DESCRIPCION_FINAL);
+
+        if (this.eventoDAO == null) {
+            throw new IllegalStateException("EventoDAO not initialized in EntradaDAOImplMySQL. Cannot fetch Evento for Entrada.");
+        }
+
+        Evento eventoAsociado = this.eventoDAO.findById(eventoId)
+                .orElseThrow(() -> new SQLException("Evento not found for ID: " + eventoId + " while mapping Entrada ID: " + id));
+
+        // We need a concrete class that implements Entrada.
+        // Using EntradaImpl.
+        String compraId = rs.getString(COLUMN_COMPRA_ID); // Retrieve compra_id from ResultSet
+
+        // Use the constructor of EntradaImpl that accepts compraId
+        EntradaImpl entrada = new EntradaImpl(id, eventoAsociado, tipoEntradaNombre, precioFinal, descripcionFinal, compraId);
+
+        return entrada;
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/EventoDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/EventoDAOImplMySQL.java
@@ -1,0 +1,430 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.EventoDAO;
+import com.eventmaster.dao.LugarDAO; // For fetching Lugar
+import com.eventmaster.dao.UsuarioDAO; // For fetching Organizador
+import com.eventmaster.model.entity.Evento;
+import com.eventmaster.model.entity.Lugar;
+import com.eventmaster.model.entity.Organizador;
+import com.eventmaster.model.entity.Usuario; // Required for casting
+import com.eventmaster.model.pattern.state.*; // For estadoActual
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class EventoDAOImplMySQL implements EventoDAO {
+
+    // Table and column names
+    private static final String TABLE_EVENTO = "evento";
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_NOMBRE = "nombre";
+    private static final String COLUMN_DESCRIPCION = "descripcion";
+    private static final String COLUMN_CATEGORIA = "categoria";
+    private static final String COLUMN_FECHA_HORA = "fecha_hora";
+    private static final String COLUMN_LUGAR_ID = "lugar_id";
+    private static final String COLUMN_ORGANIZADOR_ID = "organizador_id";
+    private static final String COLUMN_CAPACIDAD_TOTAL = "capacidad_total";
+    private static final String COLUMN_ENTRADAS_VENDIDAS = "entradas_vendidas";
+    private static final String COLUMN_ESTADO_ACTUAL = "estado_actual"; // e.g., "BORRADOR", "PUBLICADO", "CANCELADO"
+
+    // DAOs for related entities - these should be injected or available
+    // For simplicity, we'll assume they can be instantiated if needed, or better, injected via constructor
+    private LugarDAO lugarDAO;
+    private UsuarioDAO usuarioDAO; // To fetch Organizador details
+
+    // Constructor for dependency injection (preferred)
+    public EventoDAOImplMySQL(LugarDAO lugarDAO, UsuarioDAO usuarioDAO) {
+        this.lugarDAO = lugarDAO;
+        this.usuarioDAO = usuarioDAO;
+    }
+
+    // Default constructor (less ideal, requires DAOs to be new-ed up or available statically)
+    public EventoDAOImplMySQL() {
+        // This is not ideal for testability and flexibility.
+        // Consider how these dependencies will be provided in AppContextListener
+        // For now, let's assume they might be new-ed up if necessary, but this needs refinement.
+        // this.lugarDAO = new LugarDAOImplMySQL(); // Example, if such class exists
+        // this.usuarioDAO = new UsuarioDAOImplMySQL(); // Example
+        // This creates a circular dependency if EventoDAO is needed by LugarDAO/UsuarioDAO constructor.
+        // Best to inject them. For now, I'll leave them potentially null and handle it in methods,
+        // or assume they will be set by AppContextListener after construction.
+        // For the purpose of this example, I will assume they are set via AppContextListener.
+    }
+
+    // Setter methods for DAOs if not using constructor injection
+    public void setLugarDAO(LugarDAO lugarDAO) {
+        this.lugarDAO = lugarDAO;
+    }
+
+    public void setUsuarioDAO(UsuarioDAO usuarioDAO) {
+        this.usuarioDAO = usuarioDAO;
+    }
+
+
+    private static final String INSERT_EVENTO = "INSERT INTO " + TABLE_EVENTO +
+            "(" + COLUMN_ID + ", " + COLUMN_NOMBRE + ", " + COLUMN_DESCRIPCION + ", " + COLUMN_CATEGORIA + ", " +
+            COLUMN_FECHA_HORA + ", " + COLUMN_LUGAR_ID + ", " + COLUMN_ORGANIZADOR_ID + ", " + COLUMN_CAPACIDAD_TOTAL + ", " +
+            COLUMN_ENTRADAS_VENDIDAS + ", " + COLUMN_ESTADO_ACTUAL + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_EVENTO;
+    private static final String UPDATE_EVENTO = "UPDATE " + TABLE_EVENTO + " SET " +
+            COLUMN_NOMBRE + " = ?, " + COLUMN_DESCRIPCION + " = ?, " + COLUMN_CATEGORIA + " = ?, " +
+            COLUMN_FECHA_HORA + " = ?, " + COLUMN_LUGAR_ID + " = ?, " + COLUMN_ORGANIZADOR_ID + " = ?, " +
+            COLUMN_CAPACIDAD_TOTAL + " = ?, " + COLUMN_ENTRADAS_VENDIDAS + " = ?, " + COLUMN_ESTADO_ACTUAL + " = ? " +
+            "WHERE " + COLUMN_ID + " = ?";
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_EVENTO + " WHERE " + COLUMN_ID + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_EVENTO;
+    private static final String SELECT_BY_NOMBRE_CONTAINING = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_NOMBRE + " LIKE ?";
+    private static final String SELECT_BY_CATEGORIA = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_CATEGORIA + " = ?";
+    private static final String SELECT_BY_FECHA_HORA_BETWEEN = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_FECHA_HORA + " BETWEEN ? AND ?";
+    private static final String SELECT_BY_LUGAR_ID = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_LUGAR_ID + " = ?";
+    private static final String SELECT_BY_ORGANIZADOR_ID = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_ORGANIZADOR_ID + " = ?";
+    private static final String SELECT_PUBLICADOS = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_ESTADO_ACTUAL + " = 'PUBLICADO'"; // Assuming 'PUBLICADO' is the string representation
+    private static final String SELECT_FUTUROS = "SELECT * FROM " + TABLE_EVENTO + " WHERE " + COLUMN_FECHA_HORA + " > ?";
+
+
+    @Override
+    public Optional<Evento> findById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Evento by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Evento> findAll() {
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                eventos.add(mapRowToEvento(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all Eventos: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public Evento save(Evento evento) {
+        if (evento.getLugar() == null || evento.getLugar().getId() == null) {
+            System.err.println("Error saving Evento: Lugar or Lugar ID is null.");
+            // Or throw IllegalArgumentException
+            return null;
+        }
+        if (evento.getOrganizador() == null || evento.getOrganizador().getId() == null) {
+            System.err.println("Error saving Evento: Organizador or Organizador ID is null.");
+            // Or throw IllegalArgumentException
+            return null;
+        }
+
+        boolean isNew = evento.getId() == null || findById(evento.getId()).isEmpty();
+
+        if (isNew && evento.getId() == null) {
+            evento.setId(UUID.randomUUID().toString());
+        }
+
+        String sql = isNew ? INSERT_EVENTO : UPDATE_EVENTO;
+
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setString(1, evento.getNombre());
+            stmt.setString(2, evento.getDescripcion());
+            stmt.setString(3, evento.getCategoria());
+            stmt.setTimestamp(4, Timestamp.valueOf(evento.getFechaHora()));
+            stmt.setString(5, evento.getLugar().getId());
+            stmt.setString(6, evento.getOrganizador().getId());
+            stmt.setInt(7, evento.getCapacidadTotal());
+            stmt.setInt(8, evento.getEntradasVendidas());
+            stmt.setString(9, evento.getEstadoActual().getClass().getSimpleName().toUpperCase()); // e.g. "ESTADOBORRADOR" -> "BORRADOR"
+
+            if (isNew) {
+                stmt.setString(1, evento.getId()); // For INSERT, ID is the first param after column list
+                stmt.setString(2, evento.getNombre());
+                stmt.setString(3, evento.getDescripcion());
+                stmt.setString(4, evento.getCategoria());
+                stmt.setTimestamp(5, Timestamp.valueOf(evento.getFechaHora()));
+                stmt.setString(6, evento.getLugar().getId());
+                stmt.setString(7, evento.getOrganizador().getId());
+                stmt.setInt(8, evento.getCapacidadTotal());
+                stmt.setInt(9, evento.getEntradasVendidas());
+                stmt.setString(10, getEstadoString(evento.getEstadoActual()));
+            } else { // UPDATE
+                stmt.setString(1, evento.getNombre());
+                stmt.setString(2, evento.getDescripcion());
+                stmt.setString(3, evento.getCategoria());
+                stmt.setTimestamp(4, Timestamp.valueOf(evento.getFechaHora()));
+                stmt.setString(5, evento.getLugar().getId());
+                stmt.setString(6, evento.getOrganizador().getId());
+                stmt.setInt(7, evento.getCapacidadTotal());
+                stmt.setInt(8, evento.getEntradasVendidas());
+                stmt.setString(9, getEstadoString(evento.getEstadoActual()));
+                stmt.setString(10, evento.getId()); // WHERE id = ?
+            }
+
+            stmt.executeUpdate();
+            return evento;
+        } catch (SQLException e) {
+            System.err.println("Error saving Evento: " + e.getMessage());
+            e.printStackTrace(); // For more details during development
+            return null;
+        }
+    }
+
+
+    @Override
+    public void deleteById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Evento by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void delete(Evento evento) {
+        if (evento != null && evento.getId() != null) {
+            deleteById(evento.getId());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Eventos: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public List<Evento> findByNombreContaining(String nombre) {
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_NOMBRE_CONTAINING)) {
+            stmt.setString(1, "%" + nombre + "%");
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Eventos by nombre: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findByCategoria(String categoria) {
+         List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_CATEGORIA)) {
+            stmt.setString(1, categoria);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Eventos by categoria: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findByFechaHoraBetween(LocalDateTime inicio, LocalDateTime fin) {
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_FECHA_HORA_BETWEEN)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(inicio));
+            stmt.setTimestamp(2, Timestamp.valueOf(fin));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Eventos by fecha/hora: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findByLugar(Lugar lugar) {
+        if (lugar == null || lugar.getId() == null) return new ArrayList<>();
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_LUGAR_ID)) {
+            stmt.setString(1, lugar.getId());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Eventos by Lugar ID: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findByOrganizador(Organizador organizador) {
+        if (organizador == null || organizador.getId() == null) return new ArrayList<>();
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ORGANIZADOR_ID)) {
+            stmt.setString(1, organizador.getId());
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Eventos by Organizador ID: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findEventosPublicados() {
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_PUBLICADOS);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                eventos.add(mapRowToEvento(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding publicados Eventos: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    @Override
+    public List<Evento> findEventosFuturos() {
+        List<Evento> eventos = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_FUTUROS)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(LocalDateTime.now()));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    eventos.add(mapRowToEvento(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding futuros Eventos: " + e.getMessage());
+        }
+        return eventos;
+    }
+
+    private Evento mapRowToEvento(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String nombre = rs.getString(COLUMN_NOMBRE);
+        String descripcion = rs.getString(COLUMN_DESCRIPCION);
+        String categoria = rs.getString(COLUMN_CATEGORIA);
+        LocalDateTime fechaHora = rs.getTimestamp(COLUMN_FECHA_HORA).toLocalDateTime();
+        String lugarId = rs.getString(COLUMN_LUGAR_ID);
+        String organizadorId = rs.getString(COLUMN_ORGANIZADOR_ID);
+        int capacidadTotal = rs.getInt(COLUMN_CAPACIDAD_TOTAL);
+        int entradasVendidas = rs.getInt(COLUMN_ENTRADAS_VENDIDAS);
+        String estadoActualStr = rs.getString(COLUMN_ESTADO_ACTUAL);
+
+        // Fetch Lugar and Organizador
+        // This is a critical point: LugarDAO and UsuarioDAO must be available.
+        if (this.lugarDAO == null || this.usuarioDAO == null) {
+            // This indicates a configuration problem. For now, we might throw or return partial object.
+            // Throwing an exception is cleaner to signal the issue.
+            throw new IllegalStateException("LugarDAO or UsuarioDAO not initialized in EventoDAOImplMySQL");
+        }
+
+        Lugar lugar = lugarDAO.findById(lugarId)
+                .orElseThrow(() -> new SQLException("Lugar not found for ID: " + lugarId + " for Evento ID: " + id));
+        Organizador organizador = (Organizador) usuarioDAO.findById(organizadorId)
+                .filter(user -> user instanceof Organizador) // Ensure it's an Organizador
+                .orElseThrow(() -> new SQLException("Organizador not found for ID: " + organizadorId + " for Evento ID: " + id));
+
+
+        // Use the EventoBuilder to construct the Evento object
+        // This assumes EventoBuilder can be used this way or Evento has a suitable constructor/setters.
+        // For simplicity, using setters on a new Evento object if builder is complex to use post-hoc.
+        // The Evento constructor is private, expecting a builder.
+        // We need to reconstruct the state of the builder or use setters if available.
+
+        // Let's use the builder pattern as intended for construction.
+        // However, the builder is for *new* Eventos. For mapping, we might need to adapt.
+        // The Evento class uses a private constructor Evento(EventoBuilder builder).
+        // We will set fields directly after construction via builder, or use a constructor if available.
+
+        Evento.EventoBuilder builder = new Evento.EventoBuilder(nombre, organizador, lugar, fechaHora)
+            .setId(id)
+            .setDescripcion(descripcion)
+            .setCategoria(categoria)
+            .setCapacidadTotal(capacidadTotal);
+            // Note: urlsImagenes, urlsVideos, tiposEntradaDisponibles are not in the 'evento' table directly.
+            // They would typically be in related tables.
+
+        Evento evento = builder.build(); // Build the basic event
+        evento.setEntradasVendidas(entradasVendidas); // Set fields not covered by builder constructor or simple setters
+
+        // Set state
+        EstadoEvento estado;
+        // The Evento constructor sets a default state if builder.getEstadoActual() is null.
+        // We need to set the state loaded from DB.
+        switch (estadoActualStr.toUpperCase()) {
+            case "BORRADOR":
+                estado = new EstadoBorrador(evento);
+                break;
+            case "PUBLICADO":
+                estado = new EstadoPublicado(evento);
+                break;
+            case "CANCELADO":
+                estado = new EstadoCancelado(evento);
+                break;
+            case "EN_CURSO": // Assuming "EN_CURSO" is a valid string for EstadoEnCurso
+                estado = new EstadoEnCurso(evento);
+                break;
+            case "FINALIZADO":
+                estado = new EstadoFinalizado(evento);
+                break;
+            default:
+                throw new SQLException("Unknown evento estado in database: " + estadoActualStr);
+        }
+        evento.setEstadoActual(estado); // Set the state after construction
+
+        // TODO: Load urlsImagenes, urlsVideos, tiposEntradaDisponibles from their respective tables
+        // This would involve more DAOs and service logic. For now, they will be empty lists/maps.
+
+        return evento;
+    }
+     private String getEstadoString(EstadoEvento estado) {
+        if (estado instanceof EstadoBorrador) return "BORRADOR";
+        if (estado instanceof EstadoPublicado) return "PUBLICADO";
+        if (estado instanceof EstadoCancelado) return "CANCELADO";
+        if (estado instanceof EstadoEnCurso) return "EN_CURSO";
+        if (estado instanceof EstadoFinalizado) return "FINALIZADO";
+        return "DESCONOCIDO"; // Should not happen
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/LugarDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/LugarDAOImplMySQL.java
@@ -1,0 +1,218 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.LugarDAO;
+import com.eventmaster.model.entity.Lugar;
+// Import ComponenteLugar and Seccion if they need to be persisted/retrieved by this DAO specifically
+// For now, assuming Lugar's subcomponentes are handled at service layer or are simple enough not to need separate DB mapping here
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+// For tiposEventosAdmitidos and reservasPorFranja, if storing as JSON or serialized string
+// import com.google.gson.Gson; // Example if using Gson for JSON
+// import com.google.gson.reflect.TypeToken; // Example for list/map deserialization
+
+public class LugarDAOImplMySQL implements LugarDAO {
+
+    private static final String TABLE_LUGAR = "lugar";
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_NOMBRE = "nombre";
+    private static final String COLUMN_DIRECCION = "direccion";
+    // For complex fields like List<String> or Map<String, String>
+    // Option 1: Separate tables (e.g., lugar_tipos_eventos, lugar_reservas) - Normalized, relational
+    // Option 2: Store as JSON string or delimited string in a TEXT column - Denormalized, simpler for some cases
+    private static final String COLUMN_TIPOS_EVENTOS_ADMITIDOS = "tipos_eventos_admitidos"; // Assuming TEXT storing JSON array
+    private static final String COLUMN_RESERVAS_POR_FRANJA = "reservas_por_franja"; // Assuming TEXT storing JSON map
+
+    // SQL Queries
+    private static final String INSERT_LUGAR = "INSERT INTO " + TABLE_LUGAR +
+            "(" + COLUMN_ID + ", " + COLUMN_NOMBRE + ", " + COLUMN_DIRECCION + ", " +
+            COLUMN_TIPOS_EVENTOS_ADMITIDOS + ", " + COLUMN_RESERVAS_POR_FRANJA + ") VALUES (?, ?, ?, ?, ?)";
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_LUGAR + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_LUGAR;
+    private static final String UPDATE_LUGAR = "UPDATE " + TABLE_LUGAR + " SET " +
+            COLUMN_NOMBRE + " = ?, " + COLUMN_DIRECCION + " = ?, " +
+            COLUMN_TIPOS_EVENTOS_ADMITIDOS + " = ?, " + COLUMN_RESERVAS_POR_FRANJA + " = ? WHERE " + COLUMN_ID + " = ?";
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_LUGAR + " WHERE " + COLUMN_ID + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_LUGAR;
+    private static final String SELECT_BY_NOMBRE_CONTAINING = "SELECT * FROM " + TABLE_LUGAR + " WHERE " + COLUMN_NOMBRE + " LIKE ?";
+    private static final String SELECT_BY_DIRECCION_CONTAINING = "SELECT * FROM " + TABLE_LUGAR + " WHERE " + COLUMN_DIRECCION + " LIKE ?";
+
+    // private final Gson gson = new Gson(); // If using Gson for JSON serialization
+
+    @Override
+    public Optional<Lugar> findById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToLugar(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Lugar by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Lugar> findAll() {
+        List<Lugar> lugares = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                lugares.add(mapRowToLugar(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all Lugares: " + e.getMessage());
+        }
+        return lugares;
+    }
+
+    @Override
+    public Lugar save(Lugar lugar) {
+        boolean isNew = lugar.getId() == null || findById(lugar.getId()).isEmpty();
+        if (isNew && lugar.getId() == null) {
+            lugar.setId(UUID.randomUUID().toString());
+        }
+
+        // Serialize complex fields (tiposEventosAdmitidos, reservasPorFranja)
+        // For simplicity, this example assumes they are stored as plain strings.
+        // In a real scenario, use JSON or separate tables.
+        // String tiposEventosJson = gson.toJson(lugar.getTiposEventosAdmitidos());
+        // String reservasJson = gson.toJson(lugar.getReservasPorFranja());
+        // For now, let's assume these fields are not persisted or handled differently.
+        // This DAO will only handle basic fields until JSON/serialization strategy is confirmed.
+
+        String sql = isNew ? INSERT_LUGAR : UPDATE_LUGAR;
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            if (isNew) {
+                stmt.setString(1, lugar.getId());
+                stmt.setString(2, lugar.getNombre());
+                stmt.setString(3, lugar.getDireccion());
+                // Placeholder for complex fields - assuming schema might not have them yet or they are handled differently
+                stmt.setString(4, null); // tiposEventosAdmitidos
+                stmt.setString(5, null); // reservasPorFranja
+            } else { // Update
+                stmt.setString(1, lugar.getNombre());
+                stmt.setString(2, lugar.getDireccion());
+                stmt.setString(3, null); // tiposEventosAdmitidos
+                stmt.setString(4, null); // reservasPorFranja
+                stmt.setString(5, lugar.getId());
+            }
+            stmt.executeUpdate();
+            return lugar;
+        } catch (SQLException e) {
+            System.err.println("Error saving Lugar: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void deleteById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Lugar by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void delete(Lugar lugar) {
+        if (lugar != null && lugar.getId() != null) {
+            deleteById(lugar.getId());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Lugares: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public List<Lugar> findByNombreContaining(String nombre) {
+        List<Lugar> lugares = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_NOMBRE_CONTAINING)) {
+            stmt.setString(1, "%" + nombre + "%");
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    lugares.add(mapRowToLugar(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Lugares by nombre: " + e.getMessage());
+        }
+        return lugares;
+    }
+
+    @Override
+    public List<Lugar> findByDireccionContaining(String direccionFragmento) {
+        List<Lugar> lugares = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_DIRECCION_CONTAINING)) {
+            stmt.setString(1, "%" + direccionFragmento + "%");
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    lugares.add(mapRowToLugar(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Lugares by direccion: " + e.getMessage());
+        }
+        return lugares;
+    }
+
+    private Lugar mapRowToLugar(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String nombre = rs.getString(COLUMN_NOMBRE);
+        String direccion = rs.getString(COLUMN_DIRECCION);
+        // String tiposEventosJson = rs.getString(COLUMN_TIPOS_EVENTOS_ADMITIDOS);
+        // String reservasJson = rs.getString(COLUMN_RESERVAS_POR_FRANJA);
+
+        Lugar lugar = new Lugar(id, nombre, direccion);
+
+        // Deserialize complex fields if they were stored (e.g. as JSON)
+        // Type listType = new TypeToken<ArrayList<String>>() {}.getType();
+        // List<String> tiposEventos = gson.fromJson(tiposEventosJson, listType);
+        // if (tiposEventos != null) {
+        //     tiposEventos.forEach(lugar::addTipoEventoAdmitido);
+        // }
+
+        // Type mapType = new TypeToken<HashMap<String, String>>() {}.getType();
+        // Map<String, String> reservas = gson.fromJson(reservasJson, mapType);
+        // if (reservas != null) {
+        //     // Assuming Lugar has a setter for the whole map or individual additions
+        //     // lugar.setReservasPorFranja(reservas); // If a setter exists
+        //     reservas.forEach((key, value) -> {
+        //         // Need to parse key "YYYY-MM-DD-FRANJA" back to components for lugar.reservarFranja
+        //         // This part is complex and depends on how reservations are managed internally
+        //     });
+        // }
+
+        // Subcomponentes (Composite pattern) are not directly mapped here.
+        // This would require a more complex setup, possibly another table for parent-child relationships
+        // if subcomponentes are also Lugar instances or different types stored in their own tables.
+        // For now, subcomponentes list will be empty when loaded from DB by this basic DAO.
+
+        return lugar;
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/PromocionDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/PromocionDAOImplMySQL.java
@@ -1,0 +1,208 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.PromocionDAO;
+import com.eventmaster.model.Promocion;
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class PromocionDAOImplMySQL implements PromocionDAO {
+
+    // Table and column names
+    private static final String TABLE_PROMOCION = "promocion";
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_DESCRIPCION = "descripcion";
+    private static final String COLUMN_PORCENTAJE_DESCUENTO = "porcentaje_descuento";
+    private static final String COLUMN_FECHA_INICIO = "fecha_inicio";
+    private static final String COLUMN_FECHA_FIN = "fecha_fin";
+    private static final String COLUMN_TIPO_APLICABLE = "tipo_aplicable"; // "Evento", "TipoEntrada"
+    private static final String COLUMN_ID_APLICABLE = "id_aplicable";     // EventoID or TipoEntradaID/Nombre
+
+    // SQL Queries
+    private static final String INSERT_PROMOCION = "INSERT INTO " + TABLE_PROMOCION +
+            "(" + COLUMN_ID + ", " + COLUMN_DESCRIPCION + ", " + COLUMN_PORCENTAJE_DESCUENTO + ", " +
+            COLUMN_FECHA_INICIO + ", " + COLUMN_FECHA_FIN + ", " + COLUMN_TIPO_APLICABLE + ", " + COLUMN_ID_APLICABLE +
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_PROMOCION + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_PROMOCION;
+    private static final String SELECT_ACTIVAS = "SELECT * FROM " + TABLE_PROMOCION +
+            " WHERE " + COLUMN_FECHA_INICIO + " <= ? AND " + COLUMN_FECHA_FIN + " >= ?";
+    private static final String SELECT_BY_TIPO_APLICABLE = "SELECT * FROM " + TABLE_PROMOCION + " WHERE " + COLUMN_TIPO_APLICABLE + " = ?";
+    private static final String SELECT_BY_TIPO_APLICABLE_AND_ID_APLICABLE = "SELECT * FROM " + TABLE_PROMOCION +
+            " WHERE " + COLUMN_TIPO_APLICABLE + " = ? AND " + COLUMN_ID_APLICABLE + " = ?";
+
+    private static final String UPDATE_PROMOCION = "UPDATE " + TABLE_PROMOCION + " SET " +
+            COLUMN_DESCRIPCION + " = ?, " + COLUMN_PORCENTAJE_DESCUENTO + " = ?, " +
+            COLUMN_FECHA_INICIO + " = ?, " + COLUMN_FECHA_FIN + " = ?, " +
+            COLUMN_TIPO_APLICABLE + " = ?, " + COLUMN_ID_APLICABLE + " = ? " +
+            "WHERE " + COLUMN_ID + " = ?";
+
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_PROMOCION + " WHERE " + COLUMN_ID + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_PROMOCION;
+
+
+    @Override
+    public Optional<Promocion> findById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToPromocion(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Promocion by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Promocion> findAll() {
+        List<Promocion> promociones = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                promociones.add(mapRowToPromocion(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all Promociones: " + e.getMessage());
+        }
+        return promociones;
+    }
+
+    @Override
+    public List<Promocion> findActivas(LocalDateTime fechaActual) {
+        List<Promocion> promociones = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ACTIVAS)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(fechaActual));
+            stmt.setTimestamp(2, Timestamp.valueOf(fechaActual));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    promociones.add(mapRowToPromocion(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding active Promociones: " + e.getMessage());
+        }
+        return promociones;
+    }
+
+    @Override
+    public List<Promocion> findByTipoAplicable(String tipoAplicable) {
+        List<Promocion> promociones = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_TIPO_APLICABLE)) {
+            stmt.setString(1, tipoAplicable);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    promociones.add(mapRowToPromocion(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Promociones by tipoAplicable: " + e.getMessage());
+        }
+        return promociones;
+    }
+
+    @Override
+    public List<Promocion> findByTipoAplicableAndIdAplicable(String tipoAplicable, String idAplicable) {
+        List<Promocion> promociones = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_TIPO_APLICABLE_AND_ID_APLICABLE)) {
+            stmt.setString(1, tipoAplicable);
+            stmt.setString(2, idAplicable);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    promociones.add(mapRowToPromocion(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Promociones by tipoAplicable and idAplicable: " + e.getMessage());
+        }
+        return promociones;
+    }
+
+
+    @Override
+    public Promocion save(Promocion promocion) {
+        boolean isNew = promocion.getId() == null || findById(promocion.getId()).isEmpty();
+        if (isNew && promocion.getId() == null) {
+            promocion.setId(UUID.randomUUID().toString());
+        }
+
+        String sql = isNew ? INSERT_PROMOCION : UPDATE_PROMOCION;
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            if (isNew) {
+                stmt.setString(1, promocion.getId());
+                stmt.setString(2, promocion.getDescripcion());
+                stmt.setDouble(3, promocion.getPorcentajeDescuento());
+                stmt.setTimestamp(4, Timestamp.valueOf(promocion.getFechaInicio()));
+                stmt.setTimestamp(5, Timestamp.valueOf(promocion.getFechaFin()));
+                stmt.setString(6, promocion.getTipoAplicable());
+                stmt.setString(7, promocion.getIdAplicable());
+            } else { // Update
+                stmt.setString(1, promocion.getDescripcion());
+                stmt.setDouble(2, promocion.getPorcentajeDescuento());
+                stmt.setTimestamp(3, Timestamp.valueOf(promocion.getFechaInicio()));
+                stmt.setTimestamp(4, Timestamp.valueOf(promocion.getFechaFin()));
+                stmt.setString(5, promocion.getTipoAplicable());
+                stmt.setString(6, promocion.getIdAplicable());
+                stmt.setString(7, promocion.getId()); // WHERE id = ?
+            }
+            stmt.executeUpdate();
+            return promocion;
+        } catch (SQLException e) {
+            System.err.println("Error saving Promocion: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public void deleteById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Promocion by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting all Promociones: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private Promocion mapRowToPromocion(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String descripcion = rs.getString(COLUMN_DESCRIPCION);
+        double porcentajeDescuento = rs.getDouble(COLUMN_PORCENTAJE_DESCUENTO);
+        LocalDateTime fechaInicio = rs.getTimestamp(COLUMN_FECHA_INICIO).toLocalDateTime();
+        LocalDateTime fechaFin = rs.getTimestamp(COLUMN_FECHA_FIN).toLocalDateTime();
+        String tipoAplicable = rs.getString(COLUMN_TIPO_APLICABLE);
+        String idAplicable = rs.getString(COLUMN_ID_APLICABLE);
+
+        return new Promocion(id, descripcion, porcentajeDescuento, fechaInicio, fechaFin, tipoAplicable, idAplicable);
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/TipoEntradaDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/TipoEntradaDAOImplMySQL.java
@@ -1,0 +1,360 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.TipoEntradaDAO;
+import com.eventmaster.model.pattern.factory.TipoEntrada;
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID; // For generating a unique ID for each tipo_entrada definition
+
+// Assuming Gson for serializing List<String> beneficiosExtra
+// import com.google.gson.Gson;
+// import com.google.gson.reflect.TypeToken;
+// import java.lang.reflect.Type;
+
+public class TipoEntradaDAOImplMySQL implements TipoEntradaDAO {
+
+    // Table and column names
+    private static final String TABLE_TIPO_ENTRADA = "tipo_entrada_definicion"; // Table for definitions
+    private static final String COLUMN_ID = "id"; // Unique ID for this definition
+    private static final String COLUMN_EVENTO_ID = "evento_id"; // Foreign key to Evento table
+    private static final String COLUMN_NOMBRE_TIPO = "nombre_tipo"; // "General", "VIP"
+    private static final String COLUMN_PRECIO_BASE = "precio_base";
+    private static final String COLUMN_CANTIDAD_TOTAL = "cantidad_total";
+    private static final String COLUMN_CANTIDAD_DISPONIBLE = "cantidad_disponible";
+    private static final String COLUMN_LIMITE_COMPRA_POR_USUARIO = "limite_compra_por_usuario";
+    private static final String COLUMN_BENEFICIOS_EXTRA = "beneficios_extra"; // Stored as JSON String
+
+    // Decorator related fields (optional, based on schema design)
+    private static final String COLUMN_OFRECE_MERCANCIA = "ofrece_mercancia";
+    private static final String COLUMN_DESC_MERCANCIA = "desc_mercancia";
+    private static final String COLUMN_PRECIO_MERCANCIA = "precio_mercancia";
+    private static final String COLUMN_OFRECE_DESCUENTO = "ofrece_descuento";
+    private static final String COLUMN_DESC_DESCUENTO = "desc_descuento";
+    private static final String COLUMN_MONTO_DESCUENTO = "monto_descuento";
+
+
+    // SQL Queries
+    // Note: The `id` for TipoEntrada is its own primary key. `nombre_tipo` combined with `evento_id` should also be unique.
+    private static final String INSERT_TIPO_ENTRADA = "INSERT INTO " + TABLE_TIPO_ENTRADA +
+            "(" + COLUMN_ID + ", " + COLUMN_EVENTO_ID + ", " + COLUMN_NOMBRE_TIPO + ", " + COLUMN_PRECIO_BASE + ", " +
+            COLUMN_CANTIDAD_TOTAL + ", " + COLUMN_CANTIDAD_DISPONIBLE + ", " + COLUMN_LIMITE_COMPRA_POR_USUARIO + ", " + COLUMN_BENEFICIOS_EXTRA + ", " +
+            COLUMN_OFRECE_MERCANCIA + ", " + COLUMN_DESC_MERCANCIA + ", " + COLUMN_PRECIO_MERCANCIA + ", " +
+            COLUMN_OFRECE_DESCUENTO + ", " + COLUMN_DESC_DESCUENTO + ", " + COLUMN_MONTO_DESCUENTO +
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_TIPO_ENTRADA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_BY_EVENTO_ID_AND_NOMBRE = "SELECT * FROM " + TABLE_TIPO_ENTRADA +
+            " WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_NOMBRE_TIPO + " = ?";
+    private static final String SELECT_ALL_BY_EVENTO_ID = "SELECT * FROM " + TABLE_TIPO_ENTRADA + " WHERE " + COLUMN_EVENTO_ID + " = ?";
+
+    private static final String UPDATE_TIPO_ENTRADA = "UPDATE " + TABLE_TIPO_ENTRADA + " SET " +
+            COLUMN_PRECIO_BASE + " = ?, " + COLUMN_CANTIDAD_TOTAL + " = ?, " + COLUMN_CANTIDAD_DISPONIBLE + " = ?, " +
+            COLUMN_LIMITE_COMPRA_POR_USUARIO + " = ?, " + COLUMN_BENEFICIOS_EXTRA + " = ?, " +
+            COLUMN_OFRECE_MERCANCIA + " = ?, " + COLUMN_DESC_MERCANCIA + " = ?, " + COLUMN_PRECIO_MERCANCIA + " = ?, " +
+            COLUMN_OFRECE_DESCUENTO + " = ?, " + COLUMN_DESC_DESCUENTO + " = ?, " + COLUMN_MONTO_DESCUENTO + " = ? " +
+            "WHERE " + COLUMN_ID + " = ?";
+            // Note: evento_id and nombre_tipo are generally not updated once created. ID is immutable.
+
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_TIPO_ENTRADA + " WHERE " + COLUMN_ID + " = ?";
+    private static final String DELETE_BY_EVENTO_ID_AND_NOMBRE = "DELETE FROM " + TABLE_TIPO_ENTRADA +
+            " WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_NOMBRE_TIPO + " = ?";
+
+    private static final String UPDATE_CANTIDAD_DISPONIBLE = "UPDATE " + TABLE_TIPO_ENTRADA + " SET " +
+            COLUMN_CANTIDAD_DISPONIBLE + " = ? WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_NOMBRE_TIPO + " = ?";
+
+    // private final Gson gson = new Gson();
+
+    @Override
+    public TipoEntrada save(String eventoId, TipoEntrada tipoEntrada) {
+        // Check if it exists by eventoId and nombreTipo to decide insert or update
+        // However, TipoEntrada itself doesn't have an ID field. We need a unique ID for the table row.
+        // Let's assume TipoEntrada objects passed here might not have a persistent ID yet.
+        // We will generate a UUID for the DB `id` column if it's a new entry.
+        // The business key is (eventoId, nombreTipo).
+
+        Optional<TipoEntrada> existingOpt = findByEventoIdAndNombreTipo(eventoId, tipoEntrada.getNombreTipo());
+        String persistentId;
+
+        // For simplicity, beneficiosExtra is not serialized to JSON in this snippet.
+        // String beneficiosJson = gson.toJson(tipoEntrada.getBeneficiosExtra());
+        String beneficiosJson = "[]"; // Placeholder
+
+        if (existingOpt.isPresent()) {
+            // Update existing: We need the persistent ID from the loaded object.
+            // This part is tricky because the TipoEntrada object itself doesn't store its DB ID.
+            // This DAO method signature might need adjustment, or we assume `findByEventoIdAndNombreTipo`
+            // somehow fetches or associates the DB ID.
+            // For now, let's assume we need a separate `findRawById` that returns the DB ID or use a convention.
+            // This is a common issue when domain objects don't carry their persistence IDs.
+            // A common workaround: the findByEventoIdAndNombreTipo method would need to return an object
+            // that includes the database ID, or the TipoEntrada class would need an `id` field.
+
+            // Let's proceed assuming we need an ID for update.
+            // If TipoEntrada had a getId() for *its definition's unique ID*, we'd use that.
+            // Since it doesn't, the update path is problematic without fetching the ID first.
+            // For this example, let's assume an update will re-fetch the ID if needed, or the `save` is for new ones primarily.
+            // The current TipoEntradaDAO interface implies save can update.
+
+            // Simplified: If found, we'll try to update based on its properties.
+            // This requires findByEventoIdAndNombreTipo to return a TipoEntrada that contains its DB ID.
+            // Let's assume TipoEntrada needs a transient dbId field for this DAO's internal use, or we query for ID first.
+            // For now, this implementation will focus on creating new if not found by (eventoId, nombreTipo),
+            // and the UPDATE_TIPO_ENTRADA query would need an ID.
+            // This part of the design (how updates map to objects without IDs) needs refinement.
+
+            // TEMPORARY: To make progress, let's assume an update scenario means we have the ID.
+            // This is a conceptual gap in the current model/DAO interaction for updates.
+            // We'll assume `tipoEntrada` somehow has its `dbId` if it's an update.
+            // This is not robust. A better way is to have an `id` field in `TipoEntrada` for its definition.
+            // For now, let's assume an update is identified by some `id` on the `tipoEntrada` object,
+            // which is NOT currently there. So, this `save` will mostly be an INSERT.
+            // If we want to update, we'd typically fetch by ID, modify, then save.
+
+            // Let's find the ID from the DB first based on eventoId and nombreTipo for an update.
+            String tempId = getDatabaseId(eventoId, tipoEntrada.getNombreTipo());
+            if (tempId == null) { // Should not happen if existingOpt.isPresent(), but good check
+                 System.err.println("Error: Cannot find existing TipoEntrada to update for " + eventoId + "/" + tipoEntrada.getNombreTipo());
+                 return null;
+            }
+            persistentId = tempId;
+
+            try (Connection conn = DatabaseManager.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(UPDATE_TIPO_ENTRADA)) {
+                stmt.setDouble(1, tipoEntrada.getPrecioBase());
+                stmt.setInt(2, tipoEntrada.getCantidadTotal());
+                stmt.setInt(3, tipoEntrada.getCantidadDisponible());
+                stmt.setInt(4, tipoEntrada.getLimiteCompraPorUsuario());
+                stmt.setString(5, beneficiosJson); // Placeholder for JSON
+                stmt.setBoolean(6, tipoEntrada.isOfreceMercanciaOpcional());
+                stmt.setString(7, tipoEntrada.getDescripcionMercancia());
+                stmt.setDouble(8, tipoEntrada.getPrecioAdicionalMercancia());
+                stmt.setBoolean(9, tipoEntrada.isOfreceDescuentoOpcional());
+                stmt.setString(10, tipoEntrada.getDescripcionDescuento());
+                stmt.setDouble(11, tipoEntrada.getMontoDescuentoFijo());
+                stmt.setString(12, persistentId); // WHERE id = ?
+                stmt.executeUpdate();
+                // The TipoEntrada object itself is updated in memory; we return it.
+                // No new ID generated for update.
+                return tipoEntrada;
+            } catch (SQLException e) {
+                System.err.println("Error updating TipoEntrada: " + e.getMessage());
+                return null;
+            }
+
+        } else { // Insert new
+            persistentId = UUID.randomUUID().toString(); // Generate new DB ID
+            try (Connection conn = DatabaseManager.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(INSERT_TIPO_ENTRADA)) {
+                stmt.setString(1, persistentId);
+                stmt.setString(2, eventoId);
+                stmt.setString(3, tipoEntrada.getNombreTipo());
+                stmt.setDouble(4, tipoEntrada.getPrecioBase());
+                stmt.setInt(5, tipoEntrada.getCantidadTotal());
+                stmt.setInt(6, tipoEntrada.getCantidadDisponible());
+                stmt.setInt(7, tipoEntrada.getLimiteCompraPorUsuario());
+                stmt.setString(8, beneficiosJson); // Placeholder for JSON
+                stmt.setBoolean(9, tipoEntrada.isOfreceMercanciaOpcional());
+                stmt.setString(10, tipoEntrada.getDescripcionMercancia());
+                stmt.setDouble(11, tipoEntrada.getPrecioAdicionalMercancia());
+                stmt.setBoolean(12, tipoEntrada.isOfreceDescuentoOpcional());
+                stmt.setString(13, tipoEntrada.getDescripcionDescuento());
+                stmt.setDouble(14, tipoEntrada.getMontoDescuentoFijo());
+
+                stmt.executeUpdate();
+                // If TipoEntrada needed to store its own DB ID, set it here.
+                // e.g., tipoEntrada.setDbId(persistentId); (if such a field existed)
+                return tipoEntrada;
+            } catch (SQLException e) {
+                System.err.println("Error inserting TipoEntrada: " + e.getMessage());
+                return null;
+            }
+        }
+    }
+    // Helper to get DB ID, this is a bit of a hack due to TipoEntrada not having an ID field
+    private String getDatabaseId(String eventoId, String nombreTipo) {
+        String sql = "SELECT " + COLUMN_ID + " FROM " + TABLE_TIPO_ENTRADA + " WHERE " + COLUMN_EVENTO_ID + " = ? AND " + COLUMN_NOMBRE_TIPO + " = ?";
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, eventoId);
+            stmt.setString(2, nombreTipo);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString(COLUMN_ID);
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error fetching DB ID for TipoEntrada: " + e.getMessage());
+        }
+        return null;
+    }
+
+
+    @Override
+    public Optional<TipoEntrada> findById(String tipoEntradaId) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, tipoEntradaId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToTipoEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding TipoEntrada by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TipoEntrada> findByEventoIdAndNombreTipo(String eventoId, String nombreTipoEntrada) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_EVENTO_ID_AND_NOMBRE)) {
+            stmt.setString(1, eventoId);
+            stmt.setString(2, nombreTipoEntrada);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToTipoEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding TipoEntrada by EventoID and NombreTipo: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<TipoEntrada> findAllByEventoId(String eventoId) {
+        List<TipoEntrada> tiposEntrada = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL_BY_EVENTO_ID)) {
+            stmt.setString(1, eventoId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    tiposEntrada.add(mapRowToTipoEntrada(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all TipoEntrada by EventoID: " + e.getMessage());
+        }
+        return tiposEntrada;
+    }
+
+    @Override
+    public void deleteById(String tipoEntradaId) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, tipoEntradaId);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting TipoEntrada by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void deleteByEventoIdAndNombreTipo(String eventoId, String nombreTipoEntrada) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_EVENTO_ID_AND_NOMBRE)) {
+            stmt.setString(1, eventoId);
+            stmt.setString(2, nombreTipoEntrada);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting TipoEntrada by EventoID and NombreTipo: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean actualizarCantidadDisponible(String eventoId, String nombreTipoEntrada, int nuevaCantidadDisponible) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(UPDATE_CANTIDAD_DISPONIBLE)) {
+            stmt.setInt(1, nuevaCantidadDisponible);
+            stmt.setString(2, eventoId);
+            stmt.setString(3, nombreTipoEntrada);
+            int rowsAffected = stmt.executeUpdate();
+            return rowsAffected > 0;
+        } catch (SQLException e) {
+            System.err.println("Error updating cantidad disponible for TipoEntrada: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private TipoEntrada mapRowToTipoEntrada(ResultSet rs) throws SQLException {
+        // String dbId = rs.getString(COLUMN_ID); // The DB's unique ID for this definition row
+        String nombreTipo = rs.getString(COLUMN_NOMBRE_TIPO);
+        double precioBase = rs.getDouble(COLUMN_PRECIO_BASE);
+        int cantidadTotal = rs.getInt(COLUMN_CANTIDAD_TOTAL);
+        int cantidadDisponible = rs.getInt(COLUMN_CANTIDAD_DISPONIBLE);
+        int limiteCompra = rs.getInt(COLUMN_LIMITE_COMPRA_POR_USUARIO);
+        // String beneficiosJson = rs.getString(COLUMN_BENEFICIOS_EXTRA); // Placeholder
+
+        TipoEntrada tipoEntrada = new TipoEntrada(nombreTipo, precioBase, cantidadTotal, limiteCompra);
+        // Manually set cantidadDisponible as constructor initializes it to cantidadTotal
+        // This is a bit of a workaround; ideally, constructor could take initial available quantity.
+        try {
+            // Use reflection to set cantidadDisponible, as there's no direct setter for it after construction
+            // if we want to preserve the constructor logic. Or, add a setter.
+            // For simplicity, let's assume we need a way to set it.
+            // A simple solution: add a method like `setInitialQuantities(total, available)`
+            // Or, modify `reducirDisponibilidad` logic in constructor.
+            // For now, we will reconstruct and then adjust. This is not ideal.
+            // The class `TipoEntrada` should ideally have a constructor that takes `cantidadDisponible`
+            // or a setter for it for ORM purposes.
+            // HACK: To set cantidadDisponible correctly after construction:
+            if (tipoEntrada.getCantidadTotal() == cantidadDisponible) {
+                // constructor already set it right if total = available
+            } else if (cantidadDisponible < tipoEntrada.getCantidadTotal()) {
+                 // simulate sales to reduce it
+                 int toBeSold = tipoEntrada.getCantidadTotal() - cantidadDisponible;
+                 tipoEntrada.reducirDisponibilidad(toBeSold); // This has side effects (prints error if not enough)
+                                                              // This is not good.
+            }
+            // A better way: TipoEntrada needs a setter for cantidadDisponible or a constructor for loading state.
+            // Let's assume for now there's a package-private or specific setter, or modify class.
+            // To avoid modifying TipoEntrada now, this mapping will be slightly off if cantidadDisponible != cantidadTotal
+            // For now, I will call a method that would be added to TipoEntrada:
+            // tipoEntrada.forceSetCantidadDisponible(cantidadDisponible);
+            // Since this method doesn't exist, I'll log a warning.
+            if (tipoEntrada.getCantidadDisponible() != cantidadDisponible) {
+                 // System.err.println("Warning: mapRowToTipoEntrada cannot accurately set cantidadDisponible without a dedicated setter/constructor param.");
+                 // For now, we'll manually adjust it here, which is not clean.
+                 // This requires TipoEntrada to be more flexible for ORM.
+                 // Let's reflect to set it, or add a setter.
+                 // Simplest for now: the current `reducirDisponibilidad` will be used if available < total
+                 // This is still not right. The TipoEntrada needs a setter.
+                 // For the purpose of this exercise, I will assume direct field access or a setter would be added.
+                 // The current `reducirDisponibilidad` is not for setting initial state.
+                 // Let's assume the `cantidadDisponible` is accurately reflected by `reducirDisponibilidad` being called
+                 // appropriately during the lifetime of the object. When loading from DB, we are loading a snapshot.
+                 // The constructor sets cantidadDisponible = cantidadTotal. We need to overwrite this.
+                 // This is a flaw in TipoEntrada for persistence if it can't be hydrated properly.
+                 // For now, I will ignore this mismatch and it will load with cantidadDisponible = cantidadTotal
+                 // unless I modify TipoEntrada.java to add a setter or adjust constructor.
+                 // Given I cannot modify TipoEntrada.java in this step, this is a known limitation.
+                 // The `actualizarCantidadDisponible` method in DAO is key for runtime changes.
+            }
+
+
+        // Deserialize beneficiosExtra (placeholder)
+        // Type listType = new TypeToken<ArrayList<String>>() {}.getType();
+        // List<String> beneficios = gson.fromJson(beneficiosJson, listType);
+        // if (beneficios != null) {
+        //     beneficios.forEach(tipoEntrada::addBeneficioExtra);
+        // }
+
+        // Map decorator fields
+        tipoEntrada.setOfreceMercanciaOpcional(rs.getBoolean(COLUMN_OFRECE_MERCANCIA));
+        tipoEntrada.setDescripcionMercancia(rs.getString(COLUMN_DESC_MERCANCIA));
+        tipoEntrada.setPrecioAdicionalMercancia(rs.getDouble(COLUMN_PRECIO_MERCANCIA));
+        tipoEntrada.setOfreceDescuentoOpcional(rs.getBoolean(COLUMN_OFRECE_DESCUENTO));
+        tipoEntrada.setDescripcionDescuento(rs.getString(COLUMN_DESC_DESCUENTO));
+        tipoEntrada.setMontoDescuentoFijo(rs.getDouble(COLUMN_MONTO_DESCUENTO));
+
+        // If TipoEntrada stored its DB ID: (e.g. if it had a `private String dbId;` field)
+        // tipoEntrada.setDbId(dbId);
+
+        return tipoEntrada;
+    }
+}

--- a/src/main/java/com/eventmaster/dao/impl/mysql/UsuarioDAOImplMySQL.java
+++ b/src/main/java/com/eventmaster/dao/impl/mysql/UsuarioDAOImplMySQL.java
@@ -1,0 +1,183 @@
+package com.eventmaster.dao.impl.mysql;
+
+import com.eventmaster.dao.UsuarioDAO;
+import com.eventmaster.model.entity.Usuario;
+import com.eventmaster.model.entity.Asistente; // Required for specific type handling
+import com.eventmaster.model.entity.Organizador; // Required for specific type handling
+import com.eventmaster.util.DatabaseManager;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID; // For generating IDs if not auto-increment
+
+public class UsuarioDAOImplMySQL implements UsuarioDAO {
+
+    // Table and column names
+    private static final String TABLE_USUARIO = "usuario";
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_NOMBRE = "nombre";
+    private static final String COLUMN_EMAIL = "email";
+    private static final String COLUMN_PASSWORD = "password";
+    private static final String COLUMN_TIPO_USUARIO = "tipo_usuario"; // To distinguish Asistente/Organizador
+
+    // SQL Queries
+    private static final String INSERT_USUARIO = "INSERT INTO " + TABLE_USUARIO +
+            "(" + COLUMN_ID + ", " + COLUMN_NOMBRE + ", " + COLUMN_EMAIL + ", " + COLUMN_PASSWORD + ", " + COLUMN_TIPO_USUARIO + ") VALUES (?, ?, ?, ?, ?)";
+    private static final String SELECT_BY_ID = "SELECT * FROM " + TABLE_USUARIO + " WHERE " + COLUMN_ID + " = ?";
+    private static final String SELECT_BY_EMAIL = "SELECT * FROM " + TABLE_USUARIO + " WHERE " + COLUMN_EMAIL + " = ?";
+    private static final String SELECT_ALL = "SELECT * FROM " + TABLE_USUARIO;
+    private static final String UPDATE_USUARIO = "UPDATE " + TABLE_USUARIO + " SET " +
+            COLUMN_NOMBRE + " = ?, " + COLUMN_EMAIL + " = ?, " + COLUMN_PASSWORD + " = ?, " + COLUMN_TIPO_USUARIO + " = ? WHERE " + COLUMN_ID + " = ?";
+    private static final String DELETE_BY_ID = "DELETE FROM " + TABLE_USUARIO + " WHERE " + COLUMN_ID + " = ?";
+    private static final String COUNT_ALL = "SELECT COUNT(*) FROM " + TABLE_USUARIO;
+
+    @Override
+    public Optional<Usuario> findById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_ID)) {
+            stmt.setString(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToUsuario(rs));
+                }
+            }
+        } catch (SQLException e) {
+            // Log error (e.g., using a logger)
+            System.err.println("Error finding Usuario by ID: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Usuario> findByEmail(String email) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_BY_EMAIL)) {
+            stmt.setString(1, email);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToUsuario(rs));
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding Usuario by email: " + e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Usuario> findAll() {
+        List<Usuario> usuarios = new ArrayList<>();
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SELECT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                usuarios.add(mapRowToUsuario(rs));
+            }
+        } catch (SQLException e) {
+            System.err.println("Error finding all Usuarios: " + e.getMessage());
+        }
+        return usuarios;
+    }
+
+    @Override
+    public Usuario save(Usuario usuario) {
+        // Determine if it's an insert or update
+        if (usuario.getId() == null || findById(usuario.getId()).isEmpty()) {
+            // Insert new usuario
+            if (usuario.getId() == null) {
+                 usuario.setId(UUID.randomUUID().toString()); // Generate new ID
+            }
+            try (Connection conn = DatabaseManager.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(INSERT_USUARIO)) {
+                stmt.setString(1, usuario.getId());
+                stmt.setString(2, usuario.getNombre());
+                stmt.setString(3, usuario.getEmail());
+                stmt.setString(4, usuario.getPassword()); // Store password hash in real app
+                stmt.setString(5, getTipoUsuarioString(usuario));
+                stmt.executeUpdate();
+                return usuario;
+            } catch (SQLException e) {
+                System.err.println("Error inserting Usuario: " + e.getMessage());
+                // Handle error, maybe throw custom exception
+                return null; // Or throw exception
+            }
+        } else {
+            // Update existing usuario
+            try (Connection conn = DatabaseManager.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(UPDATE_USUARIO)) {
+                stmt.setString(1, usuario.getNombre());
+                stmt.setString(2, usuario.getEmail());
+                stmt.setString(3, usuario.getPassword());
+                stmt.setString(4, getTipoUsuarioString(usuario));
+                stmt.setString(5, usuario.getId());
+                stmt.executeUpdate();
+                return usuario;
+            } catch (SQLException e) {
+                System.err.println("Error updating Usuario: " + e.getMessage());
+                return null; // Or throw exception
+            }
+        }
+    }
+
+    @Override
+    public void deleteById(String id) {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(DELETE_BY_ID)) {
+            stmt.setString(1, id);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            System.err.println("Error deleting Usuario by ID: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public long count() {
+        try (Connection conn = DatabaseManager.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(COUNT_ALL);
+             ResultSet rs = stmt.executeQuery()) {
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+        } catch (SQLException e) {
+            System.err.println("Error counting Usuarios: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private Usuario mapRowToUsuario(ResultSet rs) throws SQLException {
+        String id = rs.getString(COLUMN_ID);
+        String nombre = rs.getString(COLUMN_NOMBRE);
+        String email = rs.getString(COLUMN_EMAIL);
+        String password = rs.getString(COLUMN_PASSWORD);
+        String tipoUsuario = rs.getString(COLUMN_TIPO_USUARIO);
+
+        Usuario usuario;
+        if ("ASISTENTE".equalsIgnoreCase(tipoUsuario)) {
+            // Assuming Asistente has a constructor like this or setters
+            usuario = new Asistente(id, nombre, email, password);
+        } else if ("ORGANIZADOR".equalsIgnoreCase(tipoUsuario)) {
+            // Assuming Organizador has a constructor like this or setters
+            // If Organizador has specific fields from DB, fetch them here
+            usuario = new Organizador(id, nombre, email, password);
+        } else {
+            // Handle unknown type or throw an error
+            // For now, defaulting to a generic user might be problematic if Usuario is abstract
+            // Throwing an exception or logging an error is better.
+            throw new SQLException("Unknown user type in database: " + tipoUsuario);
+        }
+        // Note: Preferences and HistorialCompras are not mapped here as they are likely in separate tables.
+        // This DAO focuses on the 'usuario' table. Related entities would need their own DAOs and service methods to link them.
+        return usuario;
+    }
+
+    private String getTipoUsuarioString(Usuario usuario) {
+        if (usuario instanceof Asistente) {
+            return "ASISTENTE";
+        } else if (usuario instanceof Organizador) {
+            return "ORGANIZADOR";
+        }
+        return "DESCONOCIDO"; // Or throw an IllegalArgumentException
+    }
+}

--- a/src/main/java/com/eventmaster/model/pattern/factory/impl/EntradaImpl.java
+++ b/src/main/java/com/eventmaster/model/pattern/factory/impl/EntradaImpl.java
@@ -1,0 +1,92 @@
+package com.eventmaster.model.pattern.factory.impl;
+
+import com.eventmaster.model.entity.Evento;
+import com.eventmaster.model.pattern.factory.Entrada;
+
+public class EntradaImpl implements Entrada {
+    private String id;
+    private Evento eventoAsociado;
+    private String tipo; // e.g., "General", "VIP"
+    private double precio;
+    private String descripcion;
+    private String compraId; // Added to associate with a Compra
+
+    public EntradaImpl(String id, Evento eventoAsociado, String tipo, double precio, String descripcion) {
+        this.id = id;
+        this.eventoAsociado = eventoAsociado;
+        this.tipo = tipo;
+        this.precio = precio;
+        this.descripcion = descripcion;
+    }
+
+    // Overloaded constructor or setter for compraId
+    public EntradaImpl(String id, Evento eventoAsociado, String tipo, double precio, String descripcion, String compraId) {
+        this(id, eventoAsociado, tipo, precio, descripcion);
+        this.compraId = compraId;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public Evento getEventoAsociado() {
+        return eventoAsociado;
+    }
+
+    public void setEventoAsociado(Evento eventoAsociado) {
+        this.eventoAsociado = eventoAsociado;
+    }
+
+    @Override
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+
+    @Override
+    public double getPrecio() {
+        return precio;
+    }
+
+    public void setPrecio(double precio) {
+        this.precio = precio;
+    }
+
+    @Override
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    // Getter and Setter for compraId
+    public String getCompraId() {
+        return compraId;
+    }
+
+    public void setCompraId(String compraId) {
+        this.compraId = compraId;
+    }
+
+    @Override
+    public String toString() {
+        return "EntradaImpl{" +
+               "id='" + id + '\'' +
+               ", eventoId=" + (eventoAsociado != null ? eventoAsociado.getId() : "null") +
+               ", tipo='" + tipo + '\'' +
+               ", precio=" + precio +
+               ", compraId='" + compraId + '\'' +
+               '}';
+    }
+}

--- a/src/main/java/com/eventmaster/util/DatabaseManager.java
+++ b/src/main/java/com/eventmaster/util/DatabaseManager.java
@@ -1,0 +1,57 @@
+package com.eventmaster.util;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class DatabaseManager {
+
+    private static final String DB_URL = "jdbc:mysql://localhost:3306/eventmaster"; // Replace with your DB URL
+    private static final String DB_USER = "your_username"; // Replace with your DB username
+    private static final String DB_PASSWORD = "your_password"; // Replace with your DB password
+
+    static {
+        try {
+            // Load the MySQL JDBC driver
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Error loading MySQL JDBC driver", e);
+        }
+    }
+
+    public static Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD);
+    }
+
+    public static void closeConnection(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                // Log error or handle as appropriate
+                System.err.println("Error closing connection: " + e.getMessage());
+            }
+        }
+    }
+
+    // Optional: Add methods for closing statements and result sets
+    public static void closeStatement(java.sql.Statement statement) {
+        if (statement != null) {
+            try {
+                statement.close();
+            } catch (SQLException e) {
+                System.err.println("Error closing statement: " + e.getMessage());
+            }
+        }
+    }
+
+    public static void closeResultSet(java.sql.ResultSet resultSet) {
+        if (resultSet != null) {
+            try {
+                resultSet.close();
+            } catch (SQLException e) {
+                System.err.println("Error closing result set: " + e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added MySQL JDBC driver dependency (manual step for you).
- Created DatabaseManager for handling DB connections.
- Updated AppContextListener to initialize MySQL DAOs and inject dependencies.
- Implemented MySQL-specific versions for all DAO interfaces:
  - UsuarioDAOImplMySQL
  - EventoDAOImplMySQL
  - LugarDAOImplMySQL
  - TipoEntradaDAOImplMySQL
  - EntradaDAOImplMySQL (with a basic EntradaImpl class)
  - CompraDAOImplMySQL
  - PromocionDAOImplMySQL
  - CodigoDescuentoDAOImplMySQL
- Created schema.sql with DDL for all tables.

Known limitations/TODOs for you:
- Implement password hashing in UsuarioDAOImplMySQL.
- Implement robust transaction management at the service layer.
- Address persistence strategies for complex fields in Lugar, TipoEntrada (e.g., lists, composite objects).
- Refine hydration of fields like TipoEntrada.cantidadDisponible and CodigoDescuento.usosActuales.
- Thoroughly test all application features with the new database backend.